### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/utils/buildPsets.py
+++ b/utils/buildPsets.py
@@ -24,12 +24,14 @@
    and stores them into a pset_dfinitions.xml files in the current directory. Warning, this can take
    a certain time (there are more than 400 definitions to retrieve)"""
 
+from __future__ import print_function
+
 import re,urllib2,os
 
 MAXTRIES = 3
 
 # read the pset list
-print "Getting psets list..."
+print("Getting psets list...")
 u = urllib2.urlopen("http://www.buildingsmart-tech.org/ifc/IFC4/Add2/html/annex/annex-b/alphabeticalorder_psets.htm")
 p = u.read()
 u.close()
@@ -39,18 +41,18 @@ psets = re.findall(">Pset_(.*?)</a>",p)
 psetdefs = ""
 failed = []
 for i,pset in enumerate(psets):
-    print i+1,"/",len(psets),": Retrieving Pset",pset
+    print(i+1,"/",len(psets),": Retrieving Pset",pset)
     for j in range(MAXTRIES):
         try:
             u = urllib2.urlopen("http://www.buildingsmart-tech.org/ifc/IFC4/final/html/psd/Pset_"+pset+".xml")
             p = u.read()
             u.close()
         except:
-            print "    Connection failed. trying one more time..."
+            print("    Connection failed. trying one more time...")
         else:
             break
     else:
-        print "    Unable to retrieve ",pset,". Skipping..."
+        print("    Unable to retrieve ",pset,". Skipping...")
         failed.append(pset)
     psetdefs += p
 psetdefs = psetdefs.replace('<?xml version="1.0" encoding="utf-8"?>','')
@@ -59,7 +61,6 @@ psetdefs = '<?xml version="1.0" encoding="utf-8"?>\n<Root>\n'+psetdefs+'</Root>'
 f = open("pset_definitions.xml","wb")
 f.write(psetdefs)
 f.close()
-print "All done! writing "+os.path.join(os.path.abspath(os.curdir),"pset_definitions.xml")
+print("All done! writing "+os.path.join(os.path.abspath(os.curdir),"pset_definitions.xml"))
 if failed:
-    print "The following psets failed and were not retrieved:",failed
-    
+    print("The following psets failed and were not retrieved:",failed)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

flake8 testing of https://github.com/yorikvanhavre/BIM_Workbench on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./BimSetup.py:194:63: F821 undefined name 'Vector'
                FreeCAD.DraftWorkingPlane.alignToPointAndAxis(Vector(0,0,0), Vector(0,0,1), 0)
                                                              ^
./BimSetup.py:194:78: F821 undefined name 'Vector'
                FreeCAD.DraftWorkingPlane.alignToPointAndAxis(Vector(0,0,0), Vector(0,0,1), 0)
                                                                             ^
./BimSetup.py:197:63: F821 undefined name 'Vector'
                FreeCAD.DraftWorkingPlane.alignToPointAndAxis(Vector(0,0,0), Vector(0,1,0), 0)
                                                              ^
./BimSetup.py:197:78: F821 undefined name 'Vector'
                FreeCAD.DraftWorkingPlane.alignToPointAndAxis(Vector(0,0,0), Vector(0,1,0), 0)
                                                                             ^
./BimSetup.py:200:63: F821 undefined name 'Vector'
                FreeCAD.DraftWorkingPlane.alignToPointAndAxis(Vector(0,0,0), Vector(1,0,0), 0)
                                                              ^
./BimSetup.py:200:78: F821 undefined name 'Vector'
                FreeCAD.DraftWorkingPlane.alignToPointAndAxis(Vector(0,0,0), Vector(1,0,0), 0)
                                                                             ^
./InitGui.py:26:20: F821 undefined name 'Workbench'
class BIMWorkbench(Workbench):
                   ^
./InitGui.py:84:28: F821 undefined name 'FreeCAD'
                return not FreeCAD.ActiveDocument is None
                           ^
./InitGui.py:86:9: F821 undefined name 'FreeCADGui'
        FreeCADGui.addCommand('BIM_ArcGroup', ArcGroupCommand())
        ^
./InitGui.py:134:32: F821 undefined name 'FreeCAD'
                    return not FreeCAD.ActiveDocument is None
                               ^
./InitGui.py:136:13: F821 undefined name 'FreeCADGui'
            FreeCADGui.addCommand('Arch_RebarTools', RebarGroupCommand())
            ^
./InitGui.py:222:20: F821 undefined name 'FreeCADGui'
        if hasattr(FreeCADGui,"draftToolBar"):
                   ^
./InitGui.py:223:28: F821 undefined name 'FreeCADGui'
            if not hasattr(FreeCADGui.draftToolBar,"loadedArchPreferences"):
                           ^
./InitGui.py:225:17: F821 undefined name 'FreeCADGui'
                FreeCADGui.addPreferencePage(":/ui/preferences-arch.ui","Arch")
                ^
./InitGui.py:226:17: F821 undefined name 'FreeCADGui'
                FreeCADGui.addPreferencePage(":/ui/preferences-archdefaults.ui","Arch")
                ^
./InitGui.py:227:17: F821 undefined name 'FreeCADGui'
                FreeCADGui.draftToolBar.loadedArchPreferences = True
                ^
./InitGui.py:228:28: F821 undefined name 'FreeCADGui'
            if not hasattr(FreeCADGui.draftToolBar,"loadedPreferences"):
                           ^
./InitGui.py:230:17: F821 undefined name 'FreeCADGui'
                FreeCADGui.addPreferencePage(":/ui/preferences-draft.ui","Draft")
                ^
./InitGui.py:231:17: F821 undefined name 'FreeCADGui'
                FreeCADGui.addPreferencePage(":/ui/preferences-draftsnap.ui","Draft")
                ^
./InitGui.py:232:17: F821 undefined name 'FreeCADGui'
                FreeCADGui.addPreferencePage(":/ui/preferences-draftvisual.ui","Draft")
                ^
./InitGui.py:233:17: F821 undefined name 'FreeCADGui'
                FreeCADGui.addPreferencePage(":/ui/preferences-drafttexts.ui","Draft")
                ^
./InitGui.py:234:17: F821 undefined name 'FreeCADGui'
                FreeCADGui.draftToolBar.loadedPreferences = True
                ^
./InitGui.py:236:9: F821 undefined name 'Log'
        Log ('Loading BIM module... done\n')
        ^
./InitGui.py:241:20: F821 undefined name 'FreeCADGui'
        if hasattr(FreeCADGui,"draftToolBar"):
                   ^
./InitGui.py:242:13: F821 undefined name 'FreeCADGui'
            FreeCADGui.draftToolBar.Activated()
            ^
./InitGui.py:243:20: F821 undefined name 'FreeCADGui'
        if hasattr(FreeCADGui,"Snapper"):
                   ^
./InitGui.py:244:13: F821 undefined name 'FreeCADGui'
            FreeCADGui.Snapper.show()
            ^
./InitGui.py:249:12: F821 undefined name 'FreeCAD'
        if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM").GetBool("FirstTime",True):
           ^
./InitGui.py:250:24: F821 undefined name 'FreeCADGui'
            todo.delay(FreeCADGui.runCommand,"BIM_Welcome")
                       ^
./InitGui.py:253:9: F821 undefined name 'FreeCADGui'
        FreeCADGui.Control.clearTaskWatcher()
        ^
./InitGui.py:266:29: F821 undefined name 'FreeCAD'
                    return (FreeCAD.ActiveDocument != None) and (FreeCADGui.Selection.getSelection() != [])
                            ^
./InitGui.py:266:66: F821 undefined name 'FreeCADGui'
                    return (FreeCAD.ActiveDocument != None) and (FreeCADGui.Selection.getSelection() != [])
                                                                 ^
./InitGui.py:268:29: F821 undefined name 'FreeCAD'
                    return (FreeCAD.ActiveDocument != None) and (not FreeCADGui.Selection.getSelection())
                            ^
./InitGui.py:268:70: F821 undefined name 'FreeCADGui'
                    return (FreeCAD.ActiveDocument != None) and (not FreeCADGui.Selection.getSelection())
                                                                     ^
./InitGui.py:270:9: F821 undefined name 'FreeCADGui'
        FreeCADGui.Control.addTaskWatcher([BimWatcher(self.draft+self.annotation,"2D geometry"),
        ^
./InitGui.py:276:12: F821 undefined name 'FreeCAD'
        if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM").GetBool("RestoreBimViews",True):
           ^
./InitGui.py:279:17: F821 undefined name 'FreeCADGui'
                FreeCADGui.runCommand("BIM_Views")
                ^
./InitGui.py:283:9: F821 undefined name 'Log'
        Log("BIM workbench activated\n")
        ^
./InitGui.py:288:20: F821 undefined name 'FreeCADGui'
        if hasattr(FreeCADGui,"draftToolBar"):
                   ^
./InitGui.py:289:13: F821 undefined name 'FreeCADGui'
            FreeCADGui.draftToolBar.Deactivated()
            ^
./InitGui.py:290:20: F821 undefined name 'FreeCADGui'
        if hasattr(FreeCADGui,"Snapper"):
                   ^
./InitGui.py:291:13: F821 undefined name 'FreeCADGui'
            FreeCADGui.Snapper.hide()
            ^
./InitGui.py:300:9: F821 undefined name 'FreeCADGui'
        FreeCADGui.Control.clearTaskWatcher()
        ^
./InitGui.py:305:9: F821 undefined name 'FreeCAD'
        FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM").SetBool("RestoreBimViews",bool(w))
        ^
./InitGui.py:307:13: F821 undefined name 'FreeCAD'
            FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM").SetInt("BimViewsSize",w.height())
            ^
./InitGui.py:310:9: F821 undefined name 'Log'
        Log("BIM workbench deactivated\n")
        ^
./InitGui.py:318:22: F821 undefined name 'FreeCADGui'
            for o in FreeCADGui.Selection.getSelection():
                     ^
./InitGui.py:336:1: F821 undefined name 'FreeCADGui'
FreeCADGui.addWorkbench(BIMWorkbench)
^
./BimClassification.py:223:41: F821 undefined name 'name'
                    children.append([ID,name,children])
                                        ^
./BimViews.py:121:82: F821 undefined name 'unicode'
    if isinstance(item,str) or ((sys.version_info.major < 3) and isinstance(item,unicode)):
                                                                                 ^
./BimViews.py:135:86: F821 undefined name 'unicode'
        if isinstance(item,str) or ((sys.version_info.major < 3) and isinstance(item,unicode)):
                                                                                     ^
./utils/buildPsets.py:32:29: E999 SyntaxError: invalid syntax
print "Getting psets list..."
                            ^
1     E999 SyntaxError: invalid syntax
51    F821 undefined name 'name'
52
```