### PR TITLE
BIM: import from new trackers module in Draft

### DIFF
--- a/BimBox.py
+++ b/BimBox.py
@@ -24,9 +24,15 @@ from __future__ import print_function
 
 """This module contains FreeCAD commands for the BIM workbench"""
 
-import os,FreeCAD,FreeCADGui,DraftTrackers,DraftVecUtils
+import os, FreeCAD, FreeCADGui, DraftVecUtils
 from PySide import QtCore,QtGui
 from DraftTools import translate
+
+try:
+    import DraftTrackers
+except Exception:
+    import draftguitools.gui_trackers as DraftTrackers
+
 
 def QT_TRANSLATE_NOOP(ctx,txt): return txt # dummy function for the QT translator
 

--- a/BimLibrary.py
+++ b/BimLibrary.py
@@ -219,7 +219,10 @@ class BIM_Library_TaskPanel:
         import Part
         self.shape = Part.read(path)
         if hasattr(FreeCADGui,"Snapper"):
-            import DraftTrackers
+            try:
+                import DraftTrackers
+            except Exception:
+                import draftguitools.gui_trackers as DraftTrackers
             self.box = DraftTrackers.ghostTracker(self.shape,dotted=True,scolor=(0.0,0.0,1.0),swidth=1.0)
             self.delta = self.shape.BoundBox.Center
             self.box.move(self.delta)


### PR DESCRIPTION
The tracker code is moved from the original `DraftTrackers` to a new module `draftguitools/gui_trackers`, with FreeCAD/FreeCAD#3092.

When that is merged, the code in BIM needs to be updated accordingly.

Forum thread: [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=40#p370895).