### PR TITLE
IfcExplorer: fix exception handling

### DIFF
--- a/BimIfcExplorer.py
+++ b/BimIfcExplorer.py
@@ -411,7 +411,7 @@ class BIM_IfcExplorer:
         while True:
             try:
                 argname = entity.attribute_name(i)
-            except AttributeError:
+            except RuntimeError:
                 break
             else:
                 try:


### PR DESCRIPTION
The wrong exception was handled. Causing an exception every time an
object was selected in tree view. Also the properties list always stayed
empty.