### PR TITLE
Fix name 'FreeCADGui' is not defined

### DIFF
--- a/BimViews.py
+++ b/BimViews.py
@@ -164,6 +164,7 @@ class BIM_Views:
 
         "selects a doc object corresponding to an item"
 
+        import FreeCADGui
         name = item.toolTip(0)
         obj = FreeCAD.ActiveDocument.getObject(name)
         if obj:


### PR DESCRIPTION
An error occurs when selecting the Level/Proxy in BIM Views Manager
```
  File "/mnt/home/.FreeCAD/Mod/BIM/BimViews.py", line 170, in select
    FreeCADGui.Selection.clearSelection()
NameError: name 'FreeCADGui' is not defined

```