### PR TITLE
Fix error name 'sys' is not defined

### DIFF
--- a/BimViews.py
+++ b/BimViews.py
@@ -23,7 +23,7 @@
 """This module contains FreeCAD commands for the BIM workbench"""
 
 
-import os
+import os, sys
 import FreeCAD
 from BimTranslateUtils import *
 


### PR DESCRIPTION
An error occurs when double clicking the Level/Proxy in the BIM Views manager

```
Traceback (most recent call last):
  File "/mnt/home/.FreeCAD/Mod/BIM/BimViews.py", line 299, in show
    # called from Python code
NameError: name 'sys' is not defined
```