### PR TITLE
BIM: import Draft globally to have access to Draft.make_layer

### DIFF
--- a/BimLayers.py
+++ b/BimLayers.py
@@ -23,7 +23,10 @@
 """Layers manager for FreeCAD"""
 
 import os
+
 import FreeCAD
+import Draft
+
 from BimTranslateUtils import *
 
 
@@ -62,7 +65,7 @@ class BIM_Layers:
         self.dialog = FreeCADGui.PySideUic.loadUi(os.path.join(os.path.dirname(__file__),"dialogLayers.ui"))
 
         # set nice icons
-        self.dialog.setWindowIcon(QtGui.QIcon(":/icons/Draft_VisGroup.svg"))
+        self.dialog.setWindowIcon(QtGui.QIcon(":/icons/Draft_Layer.svg"))
         self.dialog.buttonNew.setIcon(QtGui.QIcon(":/icons/document-new.svg"))
         self.dialog.buttonDelete.setIcon(QtGui.QIcon(":/icons/delete.svg"))
         self.dialog.buttonSelectAll.setIcon(QtGui.QIcon(":/icons/edit-select-all.svg"))
@@ -218,7 +221,6 @@ class BIM_Layers:
 
         "rebuild the model from document contents"
 
-        import Draft
         self.model.clear()
 
         # set header


### PR DESCRIPTION
Import the `Draft` module globally to have access to `Draft.makeLayer`, which internally calls `Draft.make_layer`.

Reported in the forum:
* [Using Layers, "Draft" is not defined](https://forum.freecadweb.org/viewtopic.php?f=23&t=48933)
* [New Layer -> NameError: name 'Draft' is not defined](https://forum.freecadweb.org/viewtopic.php?f=23&t=49666)

When this is merged, it will uncover an error with the legacy function `Draft.makeLayer`. This is corrected in a separate pull request made for the Draft Workbench, FreeCAD/FreeCAD#3732.