### PR TITLE
BIM: add fix for removal of listCommands in the main FreeCAD code

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -67,6 +67,9 @@ static char * IFC_xpm[] = {
         def QT_TRANSLATE_NOOP(scope, text):
             return text
 
+        if not hasattr(Gui, "listCommands"):
+            Gui.listCommands = Gui.Command.listAll
+
         import DraftTools
         import Arch
 


### PR DESCRIPTION
The error reads
```
module 'FreeCADGui' has no attribute 'listCommands'
```

This error is caused by a recent change in the main FreeCAD code, https://github.com/FreeCAD/FreeCAD/commit/9b529bc45c28e06434d371ba3cfef60de283a4dc.

The quick solution is to do this:
```py
if not hasattr(Gui, "listCommands"):
    Gui.listCommands = Gui.Command.listAll
```

Then BIM will work with versions before that commit, and for future versions that have the new method `Command.listAll`.