### PR TITLE
BIM: fix misspelling of DefaultShapeLineWidth

### DIFF
--- a/BimSetup.py
+++ b/BimSetup.py
@@ -155,7 +155,7 @@ class BIM_Setup:
         FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft").SetString("textfont",font)
         FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/TechDraw/Labels").SetString("LabelFont",font)
         linewidth = self.form.settingLinewidth.value()
-        FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View").SetInt("DefautShapeLineWidth",linewidth)
+        FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View").SetInt("DefaultShapeLineWidth",linewidth)
         FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft").SetInt("linewidth",linewidth)
         # TODO - TechDraw default line styles
         dimstyle = self.form.settingDimstyle.currentIndex()
@@ -329,7 +329,7 @@ class BIM_Setup:
             tsize = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft").GetFloat("textheight",10)
             tsize = FreeCAD.Units.Quantity(tsize,FreeCAD.Units.Length).UserString
             font = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft").GetString("textfont","Sans")
-            linewidth = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View").GetInt("DefautShapeLineWidth",2)
+            linewidth = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View").GetInt("DefaultShapeLineWidth",2)
             dimstyle = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft").GetInt("dimsymbol",0)
             dimstyle = [0,0,1,2,3][dimstyle] # less choices in our simplified dialog
             asize = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft").GetFloat("arrowsize",5)


### PR DESCRIPTION
Misspelling of `DefaultShapeLineWidth` means that the parameter is not read correctly and thus the setup has no effect.

[[ Bug ] BIM_Setup: LineWidth not handled properly](https://forum.freecadweb.org/viewtopic.php?f=23&t=48911#p435973)