### PR TITLE
handle 'Sketcher.SketchObject' object has no attribute 'IfcRole'

### DIFF
--- a/BimClassification.py
+++ b/BimClassification.py
@@ -314,6 +314,7 @@ class BIM_Classification:
 
     def updateClasses(self,search=""):
 
+        from PySide import QtCore,QtGui
         self.form.treeClass.clear()
 
         # save as default

--- a/BimIfcElements.py
+++ b/BimIfcElements.py
@@ -26,6 +26,7 @@
 
 import os
 import FreeCAD
+import FreeCADGui
 from BimTranslateUtils import *
 
 class BIM_IfcElements:
@@ -49,7 +50,7 @@ class BIM_IfcElements:
 
     def Activated(self):
 
-        import FreeCADGui
+        import Draft
         from PySide import QtCore,QtGui
         # build objects list
         self.objectslist = {}
@@ -61,9 +62,15 @@ class BIM_IfcElements:
             self.ifctypes = ArchComponent.IfcRoles
         for obj in FreeCAD.ActiveDocument.Objects:
             mat = ""
-            if hasattr(obj,"Material") and obj.Material:
-                mat = obj.Material.Name
-            self.objectslist[obj.Name] = [obj.IfcRole,mat]
+            if hasattr(obj,"Material"):
+                try:
+                    mat = obj.Material.Name
+                except AttributeError:
+                    mat=""
+                if hasattr(obj,"IfcType"):
+                    self.objectslist[obj.Name] = [obj.IfcType,mat]
+                elif hasattr(obj,"IfcRole"):
+                    self.objectslist[obj.Name] = [obj.IfcRole,mat]
 
         # load the form and set the tree model up
         self.form = FreeCADGui.PySideUic.loadUi(os.path.join(os.path.dirname(__file__),"dialogIfcElements.ui"))
@@ -434,7 +441,6 @@ class BIM_IfcElements:
 
     def checkMatChanged(self):
         
-        import FreeCADGui
         import Draft
         from PySide import QtCore,QtGui
         if FreeCADGui.Control.activeDialog():


### PR DESCRIPTION
Menu *Manage > Manage IFC Elements ...* gives this error when sketches are in the model:

    19:52:21  Running the Python command 'BIM_IfcElements' failed:
    Traceback (most recent call last):
    File "/home/vince/.FreeCAD/Mod/BIM/BimIfcElements.py", line 66, in Activated
        self.objectslist[obj.Name] = [obj.IfcRole,mat]

    'Sketcher.SketchObject' object has no attribute 'IfcRole'

and then, after changing:
```python
    if hasattr(obj,"Material") and obj.Material:
        mat = obj.Material.Name
    self.objectslist[obj.Name] = [obj.IfcRole,mat]
```
with:
```python
    if hasattr(obj,"Material"):
        try:
            mat = obj.Material.Name
        except AttributeError:
            mat=""
        if hasattr(obj,"IfcType"):
            self.objectslist[obj.Name] = [obj.IfcType,mat]
        elif hasattr(obj,"IfcRole"):
            self.objectslist[obj.Name] = [obj.IfcRole,mat]    
```
another error occurs:
    
    Running the Python command 'BIM_IfcElements' failed:
    Traceback (most recent call last):
    File "/home/vince/.FreeCAD/Mod/BIM/BimIfcElements.py", line 89, in Activated
        if o.isDerivedFrom("App::MaterialObject") or (Draft.getType(o) == "MultiMaterial"):

    name 'Draft' is not defined
After adding
```python
    import Draft
```
at the beginning of the function, the "IFC Elements Manager" finally opens.
However, if Material is not defined, an attempt to double-click on the Material row (which is supposed to trigger the Material selector), gives:

    Traceback (most recent call last):
    File "/home/vince/.FreeCAD/Mod/BIM/BimIfcElements.py", line 364, in onClickTree
          FreeCADGui.Selection.clearSelection()
    
    NameError: name 'FreeCADGui' is not defined
    
So, I added its ```import``` clause globally in the file.
Also added another missing ```import```in ```BimClassification.py```.