### PR TITLE
Add units to building size and axes distance in project setup dialog

### DIFF
--- a/dialogProject.ui
+++ b/dialogProject.ui
@@ -157,7 +157,10 @@
                <number>4</number>
               </property>
               <property name="maximum">
-               <double>9999.989999999999782</double>
+                <double>180.0</double>
+                </property>
+                <property name="minimum">
+                <double>-180.0</double>
               </property>
              </widget>
             </item>
@@ -239,7 +242,10 @@
                <number>4</number>
               </property>
               <property name="maximum">
-               <double>9999.989999999999782</double>
+               <double>90.0</double>
+              </property>
+              <property name="minimum">
+               <double>-90.0</double>
               </property>
              </widget>
             </item>

--- a/dialogProject.ui
+++ b/dialogProject.ui
@@ -278,14 +278,14 @@
             <item row="4" column="0">
              <widget class="QLabel" name="label_24">
               <property name="text">
-               <string>Gross building length</string>
+               <string>Gross building length [mm]</string>
               </property>
              </widget>
             </item>
             <item row="5" column="0">
              <widget class="QLabel" name="label_25">
               <property name="text">
-               <string>Gross building width</string>
+               <string>Gross building width [mm]</string>
               </property>
              </widget>
             </item>
@@ -313,7 +313,7 @@
             <item row="10" column="0">
              <widget class="QLabel" name="label_26">
               <property name="text">
-               <string>Distance between H axes</string>
+               <string>Distance between H axes [mm]</string>
               </property>
              </widget>
             </item>
@@ -343,7 +343,7 @@
             <item row="8" column="0">
              <widget class="QLabel" name="label_28">
               <property name="text">
-               <string>Distance between V axes</string>
+               <string>Distance between V axes [mm]</string>
               </property>
               <property name="wordWrap">
                <bool>false</bool>


### PR DESCRIPTION
As explained in #70 , building size and axes distance use by default mm, if no explicit unit is used, this is a bit surprising if you have setup other units as preferred (e.g. meters).
As it's possible to use explicit units, maybe this is not the right fix for the issue.