### PR TITLE
Correct classname for icon location

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <content>
     <workbench>
-      <classname>BIM</classname>
+      <classname>BIMWorkbench</classname>
       <subdirectory>./</subdirectory>
       <depend kind="freecad">Arch</depend>
     </workbench>


### PR DESCRIPTION
The actual name of the class in InitGui.py is BIMWorkbench.