### PR TITLE
BIM: clean up toolbar area context menu on WB deactivation

### DIFF
--- a/BimStatusBar.py
+++ b/BimStatusBar.py
@@ -304,12 +304,11 @@ def setStatusIcons(show=True):
                 statuswidget.addWidget(updatebutton)
                 QtCore.QTimer.singleShot(2500, checkUpdates) # delay a bit the check for BIM WB update...
         else:
-            if statuswidget:
-                statuswidget.hide()
-            else:
+            if statuswidget is None:
                 # when switching workbenches, the toolbar sometimes "jumps"
                 # out of the status bar to any other dock area...
                 statuswidget = mw.findChild(QtGui.QToolBar,"BIMStatusWidget")
-                if statuswidget:
-                    statuswidget.hide()
+            if statuswidget:
+                statuswidget.hide()
+                statuswidget.toggleViewAction().setVisible(False)
 

--- a/InitGui.py
+++ b/InitGui.py
@@ -504,6 +504,7 @@ static char * IFC_xpm[] = {
         if w:
             FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM").SetInt("BimViewsSize",w.height())
             w.hide()
+            w.toggleViewAction().setVisible(False)
 
         Log("BIM workbench deactivated\n")
 

--- a/InitGui.py
+++ b/InitGui.py
@@ -470,6 +470,7 @@ static char * IFC_xpm[] = {
                 FreeCADGui.runCommand("BIM_Views")
             else:
                 w.show()
+                w.toggleViewAction().setVisible(True)
 
         self.setupMultipleObjectSelection()
 


### PR DESCRIPTION
Two BIM widgets were still available in the toolbar area context menu after switching to a different workbench.