### PR TITLE
Bim: using 2 arguments for addExtension is deprecated

### DIFF
--- a/archobjects/archview.py
+++ b/archobjects/archview.py
@@ -138,7 +138,7 @@ class ArchView(object):
 
     def attach(self, obj):
         # print("running" + obj.Name + "attach() method\n")
-        obj.addExtension("App::GeoFeatureGroupExtensionPython", None)
+        obj.addExtension("App::GeoFeatureGroupExtensionPython")
         self.set_properties(obj)
 
     def execute(self, obj):

--- a/archobjects/base.py
+++ b/archobjects/base.py
@@ -53,7 +53,7 @@ class ShapeGroup(object):
         return
 
     def attach(self, obj):
-        obj.addExtension("App::GeoFeatureGroupExtensionPython", None)
+        obj.addExtension("App::GeoFeatureGroupExtensionPython")
 
     def onDocumentRestored(self, obj):
         self.Object = obj

--- a/archviewproviders/view_archview.py
+++ b/archviewproviders/view_archview.py
@@ -142,7 +142,7 @@ class ViewProviderArchView(object):
             vobj.CutMargin = 1
 
     def attach(self, vobj):
-        vobj.addExtension("Gui::ViewProviderGeoFeatureGroupExtensionPython", None)
+        vobj.addExtension("Gui::ViewProviderGeoFeatureGroupExtensionPython")
         self.ViewObject = vobj
         self.set_properties(vobj)
 

--- a/archviewproviders/view_base.py
+++ b/archviewproviders/view_base.py
@@ -51,7 +51,7 @@ class ViewProviderShapeGroup(object):
             self.ViewObject = None
 
     def attach(self, vobj):
-        vobj.addExtension("Gui::ViewProviderGeoFeatureGroupExtensionPython", None)
+        vobj.addExtension("Gui::ViewProviderGeoFeatureGroupExtensionPython")
         self.ViewObject = vobj
         self.setupShapeGroup()
 


### PR DESCRIPTION
Using 2 arguments for addExtension is deprecated. A warning to that effect is displayed in the current version.
```
OS: Windows 8 build 9600
Word size of FreeCAD: 64-bit
Version: 0.21.0.33458 (Git)
Build type: Release
Branch: master
Hash: 8b89dd29d2382c72d738c52e8974216130ffa9db
Python 3.10.12, Qt 5.15.8, Coin 4.0.0, Vtk 9.1.0, OCC 7.6.3
Locale: Dutch/Netherlands (nl_NL)
Installed mods:
```
