### PR TITLE
Update BimPreflight.py to allow prebuild version of ifcopenshell

### DIFF
--- a/BimPreflight.py
+++ b/BimPreflight.py
@@ -341,10 +341,29 @@ class BIM_Preflight_TaskPanel:
                     ifcopenshell, "schema_identifier"
                 ) and ifcopenshell.schema_identifier.startswith("IFC4"):
                     self.passed(test)
-                elif hasattr(ifcopenshell, "version") and (
-                    float(ifcopenshell.version[:3]) >= 0.6
-                ):
-                    self.passed(test)
+                elif hasattr(ifcopenshell, "version"):
+                    try:
+                        from packaging import version
+                        cur_version = version.parse(ifcopenshell.version)
+                        min_version = version.parse("0.6")
+                        if type(cur_version) == version.LegacyVersion:
+                            # Prebuild version have a version like 'v0.7.0-<GIT_COMMIT_ID>,
+                            # trying to remove the commit id.
+                            cur_version = version.parse(ifcopenshell.version.split('-')[0])
+                        if cur_version >= min_version:
+                            self.passed(test)
+                        else:
+                            msg = self.getToolTip(test)
+                            msg = (
+                                translate(
+                                    "BIM",
+                                    "The version of ifcopenshell installed on your system could not be parsed",
+                                )
+                                + " "
+                            )
+                            self.failed(test)
+                    except Exception as e:
+                        self.failed(test)
                 else:
                     msg = self.getToolTip(test)
                     msg += (

--- a/BimPreflight.py
+++ b/BimPreflight.py
@@ -1108,6 +1108,7 @@ class BIM_Preflight_TaskPanel:
                                 if not obj in objs:
                                     objs.append(obj)
             if edges:
+                import Part
                 result = FreeCAD.ActiveDocument.addObject(
                     "Part::Feature", "TinyLinesResult"
                 )


### PR DESCRIPTION
After installing a pre-compiled package of IFCOpenShell-python (according to the documentation available at [freecad.org](https://wiki.freecad.org/IfcOpenShell#Using_a_pre-compiled_IfcOpenShell_package)), I was able to do a IFC pre-flight checks.

However I get an error because the version returned by `ifcopenshell.version` does not have a standard format (x.y.z).
It is in fact appended with the git commit id to read something like this `v0.7.0-f0e03c79d'`.

This PR uses the standard python version package to read the version and in case something a git commit is detected it will try to remove it.

Here are the information about my system:

```
OS: Ubuntu Core 20 (GNOME)
Word size of FreeCAD: 64-bit
Version: 0.21.1.33668 +26 (Git) Snap 759
Build type: Release
Branch: tag: 0.21.1
Hash: f6708547a9bb3f71a4aaade12109f511a72c207c
Python 3.8.10, Qt 5.15.7, Coin 4.0.0, Vtk 7.1.1, OCC 7.6.3
Locale: English/United States (en_US)
Installed mods: 
  * Reinforcement
  * Help 1.0.3
  * A2plus 0.4.61
  * Reporting
  * ArchTextures
  * parts_library
  * dodo 1.0.0
  * WebTools 1.0.0
  * BIM 2021.12.0
  * fasteners 0.4.71
  * woodworking 0.21.30486
```

