### PR TITLE
fix request calls in getIfcOpenShell

### DIFF
--- a/BimSetup.py
+++ b/BimSetup.py
@@ -688,7 +688,7 @@ def getIfcOpenShell(force=False):
                 "Loading list of latest IfcOpenBot builds from https://github.com/IfcOpenBot/IfcOpenShell..."
             )
             url1 = "https://api.github.com/repos/IfcOpenBot/IfcOpenShell/comments?per_page=100"
-            u = urllib.request.urlopen(url1)
+            u = request.urlopen(url1)
             if u:
                 r = u.read()
                 u.close()
@@ -722,7 +722,7 @@ def getIfcOpenShell(force=False):
                             "MacroPath",
                             os.path.join(FreeCAD.getUserAppDataDir(), "Macros"),
                         )
-                        u = urllib.request.urlopen(link)
+                        u = request.urlopen(link)
                         if u:
                             if sys.version_info.major < 3:
                                 import StringIO as io


### PR DESCRIPTION
```
OS: Ubuntu Core 20 (ubuntu:GNOME/ubuntu)
Word size of FreeCAD: 64-bit
Version: 0.21.2.33771 (Git) Snap 908
Build type: Release
Branch: tag: 0.21.2
Hash: b9bfa5c5507506e4515816414cd27f4851d00489
Python 3.8.10, Qt 5.15.7, Coin 4.0.0, Vtk 7.1.1, OCC 7.6.3
Locale: English/United Kingdom (en_GB)
Installed mods: 
  * BIM 2021.12.0
```

```
20:02:31  Loading list of latest IfcOpenBot builds from https://github.com/IfcOpenBot/IfcOpenShell...
20:02:31  Traceback (most recent call last):
20:02:31    File "/home/jonathan/snap/freecad/common/Mod/BIM/./BimSetup.py", line 636, in handleLink
20:02:31      getIfcOpenShell()
20:02:31    File "/home/jonathan/snap/freecad/common/Mod/BIM/./BimSetup.py", line 691, in getIfcOpenShell
20:02:31      u = urllib.request.urlopen(url1)
20:02:32  NameError: name 'urllib' is not defined
```

Since the request object is imported from urllib with `from urllib import request` it needs to be referenced directly.