### PR TITLE
Update BIM View Manager

### DIFF
--- a/BimViews.py
+++ b/BimViews.py
@@ -31,9 +31,9 @@ import FreeCADGui
 
 from BimTranslateUtils import *
 
-
 UPDATEINTERVAL = 2000  # number of milliseconds between BIM Views window update
 PREFS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
+
 
 class BIM_Views:
     def GetResources(self):
@@ -86,13 +86,18 @@ class BIM_Views:
             toolbar = QtGui.QToolBar()
             toolbar.setIconSize(QtCore.QSize(size, size))
             dialog.horizontalLayout.addWidget(toolbar)
-            for button in ["AddLevel","AddProxy",
-                           "Delete","Toggle",
-                           "Isolate","SaveView",
-                           "Rename",]:
+            for button in [
+                "AddLevel",
+                "AddProxy",
+                "Delete",
+                "Toggle",
+                "Isolate",
+                "SaveView",
+                "Rename",
+            ]:
                 action = QtGui.QAction()
                 toolbar.addAction(action)
-                setattr(dialog,"button"+button, action)
+                setattr(dialog, "button" + button, action)
 
             # # set button icons
             dialog.buttonAddLevel.setIcon(QtGui.QIcon(":/icons/Arch_Floor_Tree.svg"))
@@ -104,15 +109,29 @@ class BIM_Views:
             dialog.buttonRename.setIcon(
                 QtGui.QIcon(":/icons/accessories-text-editor.svg")
             )
-            
+
             # set tooltips
-            dialog.buttonAddLevel.setToolTip(translate("BIM","Creates a new level"))
-            dialog.buttonAddProxy.setToolTip(translate("BIM","Creates a new Working Plane Proxy"))
-            dialog.buttonDelete.setToolTip(translate("BIM","Deletes the selected item"))
-            dialog.buttonToggle.setToolTip(translate("BIM","Toggles selected items on/off"))
-            dialog.buttonIsolate.setToolTip(translate("BIM","Turns all items off except the selected ones"))
-            dialog.buttonSaveView.setToolTip(translate("BIM","Saves the current camera position to the selected items"))
-            dialog.buttonRename.setToolTip(translate("BIM","Renames the selected item"))
+            dialog.buttonAddLevel.setToolTip(translate("BIM", "Creates a new level"))
+            dialog.buttonAddProxy.setToolTip(
+                translate("BIM", "Creates a new Working Plane Proxy")
+            )
+            dialog.buttonDelete.setToolTip(
+                translate("BIM", "Deletes the selected item")
+            )
+            dialog.buttonToggle.setToolTip(
+                translate("BIM", "Toggles selected items on/off")
+            )
+            dialog.buttonIsolate.setToolTip(
+                translate("BIM", "Turns all items off except the selected ones")
+            )
+            dialog.buttonSaveView.setToolTip(
+                translate(
+                    "BIM", "Saves the current camera position to the selected items"
+                )
+            )
+            dialog.buttonRename.setToolTip(
+                translate("BIM", "Renames the selected item")
+            )
 
             # connect signals
             dialog.buttonAddLevel.triggered.connect(self.addLevel)
@@ -182,13 +201,28 @@ class BIM_Views:
                 soloProxyHold = []
                 for obj in FreeCAD.ActiveDocument.Objects:
                     t = Draft.getType(obj)
-                    if obj and (t in ["Building", "BuildingPart", "IfcBuilding", "IfcBuildingStorey"]):
-                        if t in ["Building", "IfcBuilding"] or getattr(obj, "IfcType", "") == "Building":
+                    if obj and (
+                        t
+                        in [
+                            "Building",
+                            "BuildingPart",
+                            "IfcBuilding",
+                            "IfcBuildingStorey",
+                        ]
+                    ):
+                        if (
+                            t in ["Building", "IfcBuilding"]
+                            or getattr(obj, "IfcType", "") == "Building"
+                        ):
                             building, _ = getTreeViewItem(obj)
                             subObjs = obj.Group
                             # find every levels belongs to the building
                             for subObj in subObjs:
-                                if Draft.getType(subObj) in ["BuildingPart", "Building Storey", "IfcBuildingStorey"]:
+                                if Draft.getType(subObj) in [
+                                    "BuildingPart",
+                                    "Building Storey",
+                                    "IfcBuildingStorey",
+                                ]:
                                     lv, lvH = getTreeViewItem(subObj)
                                     subSubObjs = subObj.Group
                                     # find every working plane proxy belongs to the level
@@ -207,8 +241,15 @@ class BIM_Views:
                             treeViewItems.append(building)
                             lvHold.clear()
 
-                        if t in ["Building Storey", "IfcBuildingStorey"] or getattr(obj, "IfcType", "") == "Building Storey":
-                            if Draft.getType(getParent(obj)) in ["Building", "IfcBuilding"] or getattr(getParent(obj), "IfcType", "") == "Building":
+                        if (
+                            t in ["Building Storey", "IfcBuildingStorey"]
+                            or getattr(obj, "IfcType", "") == "Building Storey"
+                        ):
+                            if (
+                                Draft.getType(getParent(obj))
+                                in ["Building", "IfcBuilding"]
+                                or getattr(getParent(obj), "IfcType", "") == "Building"
+                            ):
                                 continue
                             lv, lvH = getTreeViewItem(obj)
                             subObjs = obj.Group
@@ -443,10 +484,9 @@ def getTreeViewItem(obj):
     if z.Value == 0:
         # override with Elevation property if available
         if hasattr(obj, "Elevation"):
-            lvHStr = FreeCAD.Units.Quantity(
-                obj.Elevation, FreeCAD.Units.Length
-            ).UserString
-    lvH = round(float(lvHStr.split(" ")[0]), 2)
+            z = FreeCAD.Units.Quantity(obj.Elevation, FreeCAD.Units.Length)
+            lvHStr = z.UserString
+    lvH = z.Value
     it = QtGui.QTreeWidgetItem([obj.Label, lvHStr])
     it.setFlags(it.flags() | QtCore.Qt.ItemIsEditable)
     it.setToolTip(0, obj.Name)

--- a/BimViews.py
+++ b/BimViews.py
@@ -355,7 +355,7 @@ class BIM_Views:
         if obj:
             if column == 0:
                 obj.Label = item.text(column)
-            if column == 1:
+            if column == 2:
                 obj.Placement.Base.z = FreeCAD.Units.parseQuantity(item.text(column))
 
     def toggle(self):
@@ -480,6 +480,9 @@ def getTreeViewItem(obj):
     from PySide import QtCore, QtGui
 
     z = FreeCAD.Units.Quantity(obj.Placement.Base.z, FreeCAD.Units.Length)
+    h = ""
+    if hasattr(obj, "Height"):
+        h = FreeCAD.Units.Quantity(obj.Height, FreeCAD.Units.Length).UserString
     lvHStr = z.UserString
     if z.Value == 0:
         # override with Elevation property if available
@@ -487,9 +490,11 @@ def getTreeViewItem(obj):
             z = FreeCAD.Units.Quantity(obj.Elevation, FreeCAD.Units.Length)
             lvHStr = z.UserString
     lvH = z.Value
-    it = QtGui.QTreeWidgetItem([obj.Label, lvHStr])
+    it = QtGui.QTreeWidgetItem([obj.Label, h, lvHStr])
     it.setFlags(it.flags() | QtCore.Qt.ItemIsEditable)
     it.setToolTip(0, obj.Name)
+    it.setToolTip(1, "Double Clicked or Press F2 to edit")
+    it.setToolTip(2, "Press F2 to edit")
     if obj.ViewObject:
         if hasattr(obj.ViewObject, "Proxy") and hasattr(
             obj.ViewObject.Proxy, "getIcon"

--- a/BimViews.py
+++ b/BimViews.py
@@ -355,8 +355,13 @@ class BIM_Views:
         if obj:
             if column == 0:
                 obj.Label = item.text(column)
+            if column == 1:
+                obj.Height = FreeCAD.Units.parseQuantity(item.text(column))
+                # TODO update every floors level which above the edited floor
+
             if column == 2:
                 obj.Placement.Base.z = FreeCAD.Units.parseQuantity(item.text(column))
+                # TODO update the floor height which 1 floor above/below the edited floor
 
     def toggle(self):
         "toggle selected item on/off"
@@ -450,8 +455,8 @@ def show(item, column=None):
         obj = FreeCAD.ActiveDocument.getObject(item)
     else:
         # called from GUI
-        if column == 1:
-            # user clicked the level field
+        if column != 0:
+            # user clicked all field (except the name field
             if vm:
                 vm.tree.editItem(item, column)
                 return
@@ -494,7 +499,7 @@ def getTreeViewItem(obj):
     it.setFlags(it.flags() | QtCore.Qt.ItemIsEditable)
     it.setToolTip(0, obj.Name)
     it.setToolTip(1, "Double Clicked or Press F2 to edit")
-    it.setToolTip(2, "Press F2 to edit")
+    it.setToolTip(2, "Double Clicked or Press F2 to edit")
     if obj.ViewObject:
         if hasattr(obj.ViewObject, "Proxy") and hasattr(
             obj.ViewObject.Proxy, "getIcon"

--- a/dialogViews.ui
+++ b/dialogViews.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>268</width>
+    <width>326</width>
     <height>322</height>
    </rect>
   </property>
@@ -56,7 +56,7 @@
       <bool>false</bool>
      </property>
      <property name="columnCount">
-      <number>2</number>
+      <number>3</number>
      </property>
      <attribute name="headerVisible">
       <bool>true</bool>
@@ -70,6 +70,11 @@
      <column>
       <property name="text">
        <string>Element</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Height</string>
       </property>
      </column>
      <column>


### PR DESCRIPTION
To enhance the usability and intuitiveness of the BIM View Manager, I propose adding the following features:

### 1. Height Field Addition:

Firstly, I believe that when designing buildings, people generally spend more time considering the height of each floor rather than its level.
so I want to add a new "Height" field in the BIM View Manager to display the height of each floor.
Also enable direct editing of the height values within the BIM View Manager interface as well.

### 2. Automated Workflows:

1. When modifying the height of a specific floor, recalculate the levels(.Placement.Base.z) of all floors above it.
2. When adjusting the level(.Placement.Base.z) of a floor, only recalculate the height for the edited floor and the one directly below it.

---
Adding floor heights in the BIM View Manager offers additional benefits. Before, changing the level of each floor did not adjust their respective heights. However, with the new automated calculation feature, structures like walls and columns set to a height of 0 will adjust automatically based on the floor or level height when the "Height Propagate" setting is true.

These enhancements will provide users with more intuitive control over floor heights and streamline the adjustment process, ultimately improving the overall functionality of the BIM View Manager.

---
only test under normal FreeCAD obj,  not sure the behavior under IFC obj

![image](https://github.com/yorikvanhavre/BIM_Workbench/assets/16606394/2c163dee-c4e5-4487-856c-0723ba625504)
