### PR TITLE
fix make slabs from multi selections

### DIFF
--- a/BimStructure.py
+++ b/BimStructure.py
@@ -25,9 +25,11 @@
 """This module contains FreeCAD commands for the BIM workbench"""
 
 import os
-import FreeCAD
-from BimTranslateUtils import *
+
 import ArchStructure
+import FreeCAD
+
+from BimTranslateUtils import *
 
 
 class BIM_Column(ArchStructure._CommandStructure):
@@ -85,8 +87,8 @@ class BIM_Slab:
         return not FreeCAD.ActiveDocument is None
 
     def Activated(self):
-        import FreeCADGui
         import DraftTools
+        import FreeCADGui
 
         self.removeCallback()
         sel = FreeCADGui.Selection.getSelection()
@@ -108,13 +110,13 @@ class BIM_Slab:
         import FreeCADGui
 
         self.removeCallback()
-        sel = FreeCADGui.Selection.getSelection()
-        if len(sel) == 1:
+        sels = FreeCADGui.Selection.getSelection()
+        for sel in sels:
             FreeCADGui.addModule("Arch")
             FreeCAD.ActiveDocument.openTransaction("Create Slab")
             FreeCADGui.doCommand(
                 "s = Arch.makeStructure(FreeCAD.ActiveDocument."
-                + sel[0].Name
+                + sel.Name
                 + ",height=200)"
             )
             FreeCADGui.doCommand('s.Label = "' + translate("BIM", "Slab") + '"')


### PR DESCRIPTION
we could select multi  shapes to create walls, beams and columns at same time, but we couldn't do this  when making slabs.
we can make slab only by select each shape one by one.

not sure its a bug or design it on purpose
this PR fix making slabs from multi selections
hope not breaking anything
![image](https://github.com/yorikvanhavre/BIM_Workbench/assets/16606394/8519ca97-cb51-423f-8684-4a087b7e0017)
  