### PR TITLE
Update icons for better legibility on dark themes

### DIFF
--- a/icons/Arch_Project_IFC.svg
+++ b/icons/Arch_Project_IFC.svg
@@ -5,16 +5,7 @@
    width="48px"
    height="48px"
    id="svg4198"
-   sodipodi:version="0.32"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   sodipodi:docname="IFC_doc.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
-   inkscape:export-filename="/home/yorik/Sources/FreeCAD/src/Gui/Icons/freecad-doc.png"
-   inkscape:export-xdpi="128"
-   inkscape:export-ydpi="128"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
@@ -43,7 +34,6 @@
          id="stop15222" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient2259">
       <stop
          style="stop-color:#ffffff;stop-opacity:1;"
@@ -66,7 +56,6 @@
          id="stop2228" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient2224"
        id="linearGradient2230"
        x1="35.996582"
@@ -76,7 +65,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(6.161836,4.033411)" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient2251">
       <stop
          style="stop-color:#ffffff;stop-opacity:1;"
@@ -88,7 +76,6 @@
          id="stop2255" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient2251"
        id="linearGradient2257"
        x1="33.396004"
@@ -98,7 +85,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(6.161836,3.658411)" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient2259"
        id="linearGradient13651"
        gradientUnits="userSpaceOnUse"
@@ -108,7 +94,6 @@
        x2="30.811172"
        y2="42.007351" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient15218"
        id="linearGradient13653"
        gradientUnits="userSpaceOnUse"
@@ -117,213 +102,7 @@
        y1="18.992140"
        x2="35.785294"
        y2="39.498238" />
-    <linearGradient
-       id="linearGradient3864">
-      <stop
-         style="stop-color:#71b2f8;stop-opacity:1;"
-         offset="0"
-         id="stop3866" />
-      <stop
-         style="stop-color:#002795;stop-opacity:1;"
-         offset="1"
-         id="stop3868" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3682">
-      <stop
-         id="stop3684"
-         offset="0"
-         style="stop-color:#ff6d0f;stop-opacity:1;" />
-      <stop
-         id="stop3686"
-         offset="1"
-         style="stop-color:#ff1000;stop-opacity:1;" />
-    </linearGradient>
-    <inkscape:perspective
-       id="perspective3148"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 32 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       id="linearGradient3864-9">
-      <stop
-         id="stop3866-1"
-         offset="0"
-         style="stop-color:#204a87;stop-opacity:1" />
-      <stop
-         id="stop3868-1"
-         offset="1"
-         style="stop-color:#729fcf;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3682-0">
-      <stop
-         style="stop-color:#a40000;stop-opacity:1"
-         offset="0"
-         id="stop3684-0" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1"
-         offset="1"
-         id="stop3686-0" />
-    </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective3148-5" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3682-0-6"
-       id="radialGradient3817-5-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2361257,0.30001695,-0.83232803,3.3883821,-499.9452,-167.33108)"
-       cx="270.58316"
-       cy="33.899986"
-       fx="270.58316"
-       fy="33.899986"
-       r="19.571428" />
-    <linearGradient
-       id="linearGradient3682-0-6">
-      <stop
-         style="stop-color:#ff390f;stop-opacity:1"
-         offset="0"
-         id="stop3684-0-7" />
-      <stop
-         style="stop-color:#ff1000;stop-opacity:1;"
-         offset="1"
-         id="stop3686-0-5" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060"
-       inkscape:collect="always">
-      <stop
-         id="stop5062"
-         offset="0"
-         style="stop-color:black;stop-opacity:1;" />
-      <stop
-         id="stop5064"
-         offset="1"
-         style="stop-color:black;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         offset="0"
-         style="stop-color:black;stop-opacity:0;" />
-      <stop
-         style="stop-color:black;stop-opacity:1;"
-         offset="0.5"
-         id="stop5056" />
-      <stop
-         id="stop5052"
-         offset="1"
-         style="stop-color:black;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient15662">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1.0000000;"
-         offset="0.0000000"
-         id="stop15664" />
-      <stop
-         style="stop-color:#f8f8f8;stop-opacity:1.0000000;"
-         offset="1.0000000"
-         id="stop15666" />
-    </linearGradient>
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       fy="64.5679"
-       fx="20.8921"
-       r="5.257"
-       cy="64.5679"
-       cx="20.8921"
-       id="aigrd3">
-      <stop
-         id="stop15573"
-         style="stop-color:#F0F0F0"
-         offset="0" />
-      <stop
-         id="stop15575"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         offset="1.0000000" />
-    </radialGradient>
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       fy="114.5684"
-       fx="20.8921"
-       r="5.256"
-       cy="114.5684"
-       cx="20.8921"
-       id="aigrd2">
-      <stop
-         id="stop15566"
-         style="stop-color:#F0F0F0"
-         offset="0" />
-      <stop
-         id="stop15568"
-         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         offset="1.0000000" />
-    </radialGradient>
-    <linearGradient
-       id="linearGradient269">
-      <stop
-         style="stop-color:#a3a3a3;stop-opacity:1.0000000;"
-         offset="0.0000000"
-         id="stop270" />
-      <stop
-         style="stop-color:#4c4c4c;stop-opacity:1.0000000;"
-         offset="1.0000000"
-         id="stop271" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient259">
-      <stop
-         style="stop-color:#fafafa;stop-opacity:1.0000000;"
-         offset="0.0000000"
-         id="stop260" />
-      <stop
-         style="stop-color:#bbbbbb;stop-opacity:1.0000000;"
-         offset="1.0000000"
-         id="stop261" />
-    </linearGradient>
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.000000,0.000000,0.000000,0.284916,0.000000,30.08928)"
-       r="15.821514"
-       fy="42.07798"
-       fx="24.306795"
-       cy="42.07798"
-       cx="24.306795"
-       id="radialGradient4548"
-       xlink:href="#linearGradient5060"
-       inkscape:collect="always" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#bebebe"
-     borderopacity="1.0000000"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="8.0000002"
-     inkscape:cx="18.1875"
-     inkscape:cy="19"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:grid-bbox="true"
-     inkscape:document-units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="1015"
-     inkscape:window-x="0"
-     inkscape:window-y="28"
-     inkscape:showpageshadow="false"
-     inkscape:window-maximized="1"
-     inkscape:pagecheckerboard="0" />
   <metadata
      id="metadata4203">
     <rdf:RDF>
@@ -370,18 +149,14 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <g
        id="g12863"
        transform="matrix(1.2108584,0,0,1.2108584,-12.827654,-10.483764)">
       <path
          style="fill:url(#linearGradient13653);fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
          d="m 15.072946,10.500852 h 29.856385 c 0.31574,0 0.569926,0.253093 0.569926,0.567472 v 27.167362 c 0,2.476452 -6.87981,8.303087 -9.267932,8.303087 H 15.072946 c -0.31574,0 -0.569926,-0.253092 -0.569926,-0.567473 V 11.068324 c 0,-0.314379 0.254186,-0.567472 0.569926,-0.567472 z"
-         id="rect12413"
-         sodipodi:nodetypes="ccccccccc"
-         inkscape:connector-curvature="0" />
+         id="rect12413" />
       <rect
          ry="0.0000000"
          rx="0.0000000"
@@ -392,47 +167,63 @@
          id="rect15244"
          style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient13651);stroke-width:1.00000083;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <path
-         sodipodi:nodetypes="cccc"
          id="path2210"
          d="m 36.220918,46.536966 c 2.030418,0.329898 9.588793,-4.529929 9.284411,-8.497844 -1.563262,2.423097 -4.758522,1.286738 -8.86728,1.445748 0,0 0.395369,6.552096 -0.417131,7.052096 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient2230);fill-opacity:1;fill-rule:evenodd;stroke:#868a84;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
-         inkscape:connector-curvature="0" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient2230);fill-opacity:1;fill-rule:evenodd;stroke:#868a84;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
       <path
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.36931817;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2257);stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
          d="m 37.671355,44.345464 c 1.369779,-0.683829 4.428249,-2.146465 5.72763,-4.027469 -1.596094,0.680055 -2.94781,0.209496 -5.702334,0.190405 0,0 0.162322,3.062094 -0.0253,3.837064 z"
-         id="path2247"
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0" />
+         id="path2247" />
     </g>
-    <g
-       id="layer1-67"
-       inkscape:label="Layer 1"
-       transform="matrix(0.48156499,0,0,0.48156499,7.6209748,7.6801114)">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a32187;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 23.493051,22.924165 c -1.538134,0 -3.091954,0.568446 -4.270552,1.747044 L 6.8961342,36.997574 c -2.3571939,2.357194 -2.3571939,6.183909 0,8.541103 L 19.222499,57.865042 c 2.357194,2.357194 6.13538,2.357194 8.492574,0 L 40.041438,45.538677 c 2.357194,-2.357194 2.357194,-6.183909 0,-8.541103 L 27.715073,24.671209 c -1.178597,-1.178598 -2.683889,-1.747044 -4.222022,-1.747044 z m 0,7.424936 c 0.916749,0 1.821047,0.316649 2.523507,1.019109 l 7.327879,7.376408 c 1.404921,1.404921 1.404921,3.642094 0,5.047015 l -7.327879,7.376408 c -1.404921,1.404921 -3.690623,1.404921 -5.095544,0 l -7.327879,-7.376408 c -1.40492,-1.404921 -1.40492,-3.642094 0,-5.047015 l 7.327879,-7.376408 c 0.702461,-0.70246 1.655287,-1.019109 2.572037,-1.019109 z"
-         id="rect3022-4"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#1b8fa7;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 41.379157,23.102951 c -1.538133,0 -3.091954,0.568446 -4.270552,1.747043 L 24.78224,37.176359 c -2.357194,2.357194 -2.357194,6.18391 0,8.541104 l 12.326365,12.326364 c 2.357194,2.357194 6.13538,2.357194 8.492574,0 L 57.927544,45.717463 c 2.357194,-2.357194 2.357194,-6.18391 0,-8.541104 L 45.601179,24.849994 C 44.422582,23.671397 42.91729,23.102951 41.379157,23.102951 Z m 0,7.424936 c 0.916749,0 1.821047,0.316648 2.523507,1.019109 l 7.327879,7.376407 c 1.404921,1.404922 1.404921,3.642094 0,5.047016 l -7.327879,7.376407 c -1.404921,1.404921 -3.690623,1.404921 -5.095544,0 l -7.327879,-7.376407 c -1.404921,-1.404922 -1.404921,-3.642094 0,-5.047016 l 7.327879,-7.376407 c 0.702461,-0.702461 1.655287,-1.019109 2.572037,-1.019109 z"
-         id="rect3022-4-8"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#004a95;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 22.088093,5.565902 c -1.538133,0 -3.091953,0.5684461 -4.270551,1.7470438 L 5.491177,19.639311 c -2.3571938,2.357194 -2.3571938,6.18391 0,8.541103 l 12.326365,12.326365 c 2.357194,2.357194 6.13538,2.357194 8.492574,0 L 38.636481,28.180414 c 2.357194,-2.357193 2.357194,-6.183909 0,-8.541103 L 26.310116,7.3129458 C 25.131518,6.1343481 23.626227,5.565902 22.088093,5.565902 Z m 0,7.424936 c 0.91675,0 1.821048,0.316649 2.523508,1.01911 l 7.327879,7.376407 c 1.404921,1.404921 1.404921,3.642094 0,5.047016 l -7.327879,7.376407 c -1.404921,1.404921 -3.690623,1.404921 -5.095544,0 l -7.327878,-7.376407 c -1.404921,-1.404922 -1.404921,-3.642095 0,-5.047016 l 7.327878,-7.376407 c 0.70246,-0.702461 1.655287,-1.01911 2.572036,-1.01911 z"
-         id="rect3022-7"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#da0640;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 39.971816,4.6619318 c -1.538133,0 -3.091954,0.5684461 -4.270552,1.7470438 l -5.192602,5.1926024 4.222022,4.173494 2.669095,-2.669095 c 0.702461,-0.702461 1.655288,-1.019109 2.572037,-1.019109 0.916749,0 1.821047,0.316648 2.523508,1.019109 l 7.327878,7.376408 c 1.404921,1.404921 1.404921,3.642094 0,5.047015 l -7.327878,7.376408 c -1.388531,1.38853 -3.63841,1.40466 -5.047016,0.04853 l -4.222023,4.173493 2.474979,2.474979 c 2.357194,2.357194 6.135381,2.357194 8.492574,0 L 56.520203,27.276444 c 2.357194,-2.357194 2.357194,-6.183909 0,-8.541103 L 44.193838,6.4089756 C 43.015241,5.2303779 41.509949,4.6619318 39.971816,4.6619318 Z M 26.335168,15.775072 23.374899,18.735341 c -2.357194,2.357194 -2.357194,6.183909 0,8.541103 l 3.88232,3.88232 4.173493,-4.222023 -1.358811,-1.407341 c -1.404922,-1.404921 -1.404922,-3.642094 0,-5.047015 l 0.48529,-0.48529 z"
-         id="rect3022"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a32187;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-         d="m 23.471957,22.908835 c -1.538133,0 -3.091954,0.568446 -4.270551,1.747043 L 6.8750408,36.982243 c -2.3571939,2.357194 -2.3571939,6.18391 0,8.541104 l 2.7661527,2.766152 4.2705515,-4.173493 -0.339703,-0.339703 c -1.404921,-1.404922 -1.404921,-3.642094 0,-5.047016 L 20.89992,31.35288 c 0.702461,-0.702461 1.655288,-1.019109 2.572037,-1.019109 0.916749,0 1.821047,0.316648 2.523508,1.019109 l 0.436761,0.436761 4.270552,-4.124965 -3.008798,-3.008798 c -1.178598,-1.178597 -2.68389,-1.747043 -4.222023,-1.747043 z"
-         id="rect3022-4-4"
-         inkscape:connector-curvature="0" />
-    </g>
+    <path
+       class="cls-4"
+       d="m 25.934197,25.041075 3.273166,-3.294778 0.01555,0.01555 2.496781,-2.510183 -0.464448,-0.462725 a 2.9115436,2.9115548 0 0 0 -4.117378,0.0134 l -3.718173,3.74281 z"
+       id="path7"
+       style="display:inline;fill:#00a3b7;stroke:none;stroke-width:1.00001" />
+    <path
+       class="cls-4"
+       d="m 30.121565,36.152424 7.193104,-7.240227 a 2.9115436,2.9115548 0 0 0 -0.013,-4.117393 l -2.455735,-2.439322 -2.496777,2.512773 2.007274,1.994322 -6.303088,6.34416 -7.662294,-7.611783 -0.445008,0.447601 a 2.9111114,2.9111227 0 0 0 0.01339,4.117394 l 6.044732,6.005431 a 2.9115436,2.9115548 0 0 0 4.117372,-0.013 z"
+       id="path8"
+       style="display:inline;fill:#00a3b7;stroke:none;stroke-width:1.00001" />
+    <path
+       class="cls-1"
+       d="m 25.763974,19.726914 -3.294767,-3.273607 0.0151,-0.0151 -2.513203,-2.497222 -0.460125,0.463585 a 2.9111114,2.9111227 0 0 0 0.0134,4.116963 l 3.742803,3.718614 z"
+       id="path1"
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#e62531;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000" />
+    <path
+       class="cls-1"
+       d="M 36.874409,15.539532 29.633786,8.345974 a 2.9111114,2.9111227 0 0 0 -4.116942,0.0134 l -2.439754,2.455747 2.513204,2.496789 1.994744,-2.007714 6.344131,6.305705 -7.612613,7.660162 0.448034,0.445012 a 2.9115436,2.9115548 0 0 0 4.117378,-0.0134 l 6.005407,-6.045188 a 2.9111114,2.9111227 0 0 0 -0.013,-4.116958 z"
+       id="path2"
+       style="display:inline;fill:#e62531;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       class="cls-2"
+       d="m 20.680114,25.273079 3.294769,3.273614 -0.01514,0.01514 2.513198,2.496792 0.46186,-0.463156 a 2.9111114,2.9111227 0 0 0 -0.0134,-4.116957 l -3.745389,-3.718621 z"
+       id="path3"
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#b62f88;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000" />
+    <path
+       class="cls-2"
+       d="m 9.569671,29.460463 7.240624,7.193563 a 2.9111114,2.9111227 0 0 0 4.116947,-0.0134 L 23.36699,34.184877 20.853794,31.68809 18.85905,33.695806 12.514917,27.392262 20.12753,19.729935 19.679501,19.284923 a 2.9111114,2.9111227 0 0 0 -4.116947,0.0134 l -6.005843,6.045183 a 2.9111114,2.9111227 0 0 0 0.01295,4.116958 z"
+       id="path4"
+       style="display:inline;fill:#b62f88;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       class="cls-3"
+       d="m 20.540564,19.927385 -3.273596,3.294779 -0.01514,-0.01555 -2.497212,2.513208 0.463584,0.460565 a 2.9111114,2.9111227 0 0 0 4.116948,-0.0134 l 3.718599,-3.742809 z"
+       id="path5"
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#0063a7;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000" />
+    <path
+       class="cls-3"
+       d="m 16.353197,8.816898 -7.193529,7.240224 a 2.9115436,2.9115548 0 0 0 0.0134,4.117392 l 2.455736,2.439328 2.496778,-2.513207 -2.007703,-1.994321 6.30568,-6.344591 7.660137,7.612646 0.445004,-0.447605 A 2.9115436,2.9115548 0 0 0 26.5153,14.809375 L 20.470139,8.803938 a 2.9111114,2.9111227 0 0 0 -4.116942,0.01295 z"
+       id="path6"
+       style="display:inline;fill:#0063a7;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       class="cls-4"
+       d="m 25.934197,25.041075 3.273166,-3.294778 0.01555,0.01555 2.496781,-2.510183 -0.464448,-0.462725 a 2.9115436,2.9115548 0 0 0 -4.117378,0.0134 l -3.718173,3.74281 z"
+       id="path16"
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#00a3b7;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000" />
+    <path
+       class="cls-4"
+       d="m 30.121565,36.152424 7.193104,-7.240227 a 2.9115436,2.9115548 0 0 0 -0.013,-4.117393 l -2.455735,-2.439322 -2.496777,2.512773 2.007274,1.994322 -6.303088,6.34416 -7.662294,-7.611783 -0.445008,0.447601 a 2.9111114,2.9111227 0 0 0 0.01339,4.117394 l 6.044732,6.005431 a 2.9115436,2.9115548 0 0 0 4.117372,-0.013 z"
+       id="path17"
+       style="display:inline;fill:#00a3b7;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/icons/BIM_IfcElements.svg
+++ b/icons/BIM_IfcElements.svg
@@ -2,28 +2,19 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="48.000000px"
    height="48.000000px"
    id="svg249"
-   sodipodi:version="0.32"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="BIM_IfcElements.svg"
-   inkscape:export-filename="/home/jimmac/gfx/novell/pdes/trunk/docs/BIGmime-text.png"
-   inkscape:export-xdpi="240.00000"
-   inkscape:export-ydpi="240.00000"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3">
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5060"
        id="radialGradient5031"
        gradientUnits="userSpaceOnUse"
@@ -34,7 +25,6 @@
        fy="486.64789"
        r="117.14286" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5060">
       <stop
          style="stop-color:black;stop-opacity:1;"
@@ -46,7 +36,6 @@
          id="stop5064" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5060"
        id="radialGradient5029"
        gradientUnits="userSpaceOnUse"
@@ -72,7 +61,6 @@
          id="stop5052" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5048"
        id="linearGradient5027"
        gradientUnits="userSpaceOnUse"
@@ -81,29 +69,6 @@
        y1="366.64789"
        x2="302.85715"
        y2="609.50507" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4542">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4544" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4546" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4542"
-       id="radialGradient4548"
-       cx="24.306795"
-       cy="42.07798"
-       fx="24.306795"
-       fy="42.07798"
-       r="15.821514"
-       gradientTransform="matrix(1.000000,0.000000,0.000000,0.284916,-6.310056e-16,30.08928)"
-       gradientUnits="userSpaceOnUse" />
     <linearGradient
        id="linearGradient15662">
       <stop
@@ -171,21 +136,6 @@
          offset="1.0000000"
          id="stop261" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient12512">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1.0000000;"
-         offset="0.0000000"
-         id="stop12513" />
-      <stop
-         style="stop-color:#fff520;stop-opacity:0.89108908;"
-         offset="0.50000000"
-         id="stop12517" />
-      <stop
-         style="stop-color:#fff300;stop-opacity:0.0000000;"
-         offset="1.0000000"
-         id="stop12514" />
-    </linearGradient>
     <radialGradient
        r="37.751713"
        fy="3.7561285"
@@ -195,8 +145,7 @@
        gradientTransform="matrix(0.968273,0.000000,0.000000,1.032767,3.353553,0.646447)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15656"
-       xlink:href="#linearGradient269"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient269" />
     <radialGradient
        r="86.708450"
        fy="35.736916"
@@ -206,8 +155,7 @@
        gradientTransform="scale(0.960493,1.041132)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15658"
-       xlink:href="#linearGradient259"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient259" />
     <radialGradient
        r="38.158695"
        fy="7.2678967"
@@ -217,10 +165,8 @@
        gradientTransform="matrix(0.968273,0.000000,0.000000,1.032767,3.353553,0.646447)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15668"
-       xlink:href="#linearGradient15662"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient15662" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#aigrd2"
        id="radialGradient2283"
        gradientUnits="userSpaceOnUse"
@@ -231,7 +177,6 @@
        fy="114.5684"
        r="5.256" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#aigrd3"
        id="radialGradient2285"
        gradientUnits="userSpaceOnUse"
@@ -242,26 +187,6 @@
        fy="64.5679"
        r="5.257" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="0.32941176"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="24.633015"
-     inkscape:cy="26.502488"
-     inkscape:current-layer="layer4"
-     showgrid="false"
-     inkscape:grid-bbox="true"
-     inkscape:document-units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="1051"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:showpageshadow="false"
-     inkscape:window-maximized="1" />
   <metadata
      id="metadata4">
     <rdf:RDF>
@@ -270,7 +195,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Jakub Steiner</dc:title>
@@ -298,9 +222,7 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Shadow"
-     id="layer6"
-     inkscape:groupmode="layer">
+     id="layer6">
     <g
        style="display:inline"
        id="g5022"
@@ -313,21 +235,17 @@
          id="rect4173"
          style="opacity:0.40206185;color:black;fill:url(#linearGradient5027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
       <path
-         sodipodi:nodetypes="cccc"
          id="path5058"
          d="M -219.61876,-150.68038 C -219.61876,-150.68038 -219.61876,327.65041 -219.61876,327.65041 C -76.744594,328.55086 125.78146,220.48075 125.78138,88.454235 C 125.78138,-43.572302 -33.655436,-150.68036 -219.61876,-150.68038 z "
          style="opacity:0.40206185;color:black;fill:url(#radialGradient5029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
       <path
          style="opacity:0.40206185;color:black;fill:url(#radialGradient5031);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
          d="M -1559.2523,-150.68038 C -1559.2523,-150.68038 -1559.2523,327.65041 -1559.2523,327.65041 C -1702.1265,328.55086 -1904.6525,220.48075 -1904.6525,88.454235 C -1904.6525,-43.572302 -1745.2157,-150.68036 -1559.2523,-150.68038 z "
-         id="path5018"
-         sodipodi:nodetypes="cccc" />
+         id="path5018" />
     </g>
   </g>
   <g
      id="layer1"
-     inkscape:label="Base"
-     inkscape:groupmode="layer"
      style="display:inline">
     <rect
        ry="1.1490486"
@@ -406,49 +324,56 @@
          style="fill:url(#radialGradient2285);fill-rule:nonzero;stroke:none;stroke-miterlimit:4.0000000" />
     </g>
     <path
-       sodipodi:nodetypes="cc"
        id="path15672"
        d="M 11.505723,5.4942766 L 11.505723,43.400869"
        style="fill:none;fill-opacity:0.75000000;fill-rule:evenodd;stroke:#000000;stroke-width:0.98855311;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.0000000;stroke-opacity:0.017543854" />
     <path
-       sodipodi:nodetypes="cc"
        id="path15674"
        d="M 12.500000,5.0205154 L 12.500000,43.038228"
        style="fill:none;fill-opacity:0.75000000;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.0000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.0000000;stroke-opacity:0.20467831" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer4"
-     inkscape:label="new"
      style="display:inline">
-    <g
-       transform="matrix(0.44650328,0,0,0.44650328,11.18688,9.4761318)"
-       id="g835">
-      <path
-         inkscape:connector-curvature="0"
-         id="rect3022-4"
-         d="m 23.493051,22.924165 c -1.538134,0 -3.091954,0.568446 -4.270552,1.747044 L 6.8961342,36.997574 c -2.3571939,2.357194 -2.3571939,6.183909 0,8.541103 L 19.222499,57.865042 c 2.357194,2.357194 6.13538,2.357194 8.492574,0 L 40.041438,45.538677 c 2.357194,-2.357194 2.357194,-6.183909 0,-8.541103 L 27.715073,24.671209 c -1.178597,-1.178598 -2.683889,-1.747044 -4.222022,-1.747044 z m 0,7.424936 c 0.916749,0 1.821047,0.316649 2.523507,1.019109 l 7.327879,7.376408 c 1.404921,1.404921 1.404921,3.642094 0,5.047015 l -7.327879,7.376408 c -1.404921,1.404921 -3.690623,1.404921 -5.095544,0 l -7.327879,-7.376408 c -1.40492,-1.404921 -1.40492,-3.642094 0,-5.047015 l 7.327879,-7.376408 c 0.702461,-0.70246 1.655287,-1.019109 2.572037,-1.019109 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a32187;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="rect3022-4-8"
-         d="m 41.379157,23.102951 c -1.538133,0 -3.091954,0.568446 -4.270552,1.747043 L 24.78224,37.176359 c -2.357194,2.357194 -2.357194,6.18391 0,8.541104 l 12.326365,12.326364 c 2.357194,2.357194 6.13538,2.357194 8.492574,0 L 57.927544,45.717463 c 2.357194,-2.357194 2.357194,-6.18391 0,-8.541104 L 45.601179,24.849994 C 44.422582,23.671397 42.91729,23.102951 41.379157,23.102951 Z m 0,7.424936 c 0.916749,0 1.821047,0.316648 2.523507,1.019109 l 7.327879,7.376407 c 1.404921,1.404922 1.404921,3.642094 0,5.047016 l -7.327879,7.376407 c -1.404921,1.404921 -3.690623,1.404921 -5.095544,0 l -7.327879,-7.376407 c -1.404921,-1.404922 -1.404921,-3.642094 0,-5.047016 l 7.327879,-7.376407 c 0.702461,-0.702461 1.655287,-1.019109 2.572037,-1.019109 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#1b8fa7;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="rect3022-7"
-         d="m 22.088093,5.565902 c -1.538133,0 -3.091953,0.5684461 -4.270551,1.7470438 L 5.491177,19.639311 c -2.3571938,2.357194 -2.3571938,6.18391 0,8.541103 l 12.326365,12.326365 c 2.357194,2.357194 6.13538,2.357194 8.492574,0 L 38.636481,28.180414 c 2.357194,-2.357193 2.357194,-6.183909 0,-8.541103 L 26.310116,7.3129458 C 25.131518,6.1343481 23.626227,5.565902 22.088093,5.565902 Z m 0,7.424936 c 0.91675,0 1.821048,0.316649 2.523508,1.01911 l 7.327879,7.376407 c 1.404921,1.404921 1.404921,3.642094 0,5.047016 l -7.327879,7.376407 c -1.404921,1.404921 -3.690623,1.404921 -5.095544,0 l -7.327878,-7.376407 c -1.404921,-1.404922 -1.404921,-3.642095 0,-5.047016 l 7.327878,-7.376407 c 0.70246,-0.702461 1.655287,-1.01911 2.572036,-1.01911 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#004a95;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="rect3022"
-         d="m 39.971816,4.6619318 c -1.538133,0 -3.091954,0.5684461 -4.270552,1.7470438 l -5.192602,5.1926024 4.222022,4.173494 2.669095,-2.669095 c 0.702461,-0.702461 1.655288,-1.019109 2.572037,-1.019109 0.916749,0 1.821047,0.316648 2.523508,1.019109 l 7.327878,7.376408 c 1.404921,1.404921 1.404921,3.642094 0,5.047015 l -7.327878,7.376408 c -1.388531,1.38853 -3.63841,1.40466 -5.047016,0.04853 l -4.222023,4.173493 2.474979,2.474979 c 2.357194,2.357194 6.135381,2.357194 8.492574,0 L 56.520203,27.276444 c 2.357194,-2.357194 2.357194,-6.183909 0,-8.541103 L 44.193838,6.4089756 C 43.015241,5.2303779 41.509949,4.6619318 39.971816,4.6619318 Z M 26.335168,15.775072 23.374899,18.735341 c -2.357194,2.357194 -2.357194,6.183909 0,8.541103 l 3.88232,3.88232 4.173493,-4.222023 -1.358811,-1.407341 c -1.404922,-1.404921 -1.404922,-3.642094 0,-5.047015 l 0.48529,-0.48529 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#da0640;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="rect3022-4-4"
-         d="m 23.471957,22.908835 c -1.538133,0 -3.091954,0.568446 -4.270551,1.747043 L 6.8750408,36.982243 c -2.3571939,2.357194 -2.3571939,6.18391 0,8.541104 l 2.7661527,2.766152 4.2705515,-4.173493 -0.339703,-0.339703 c -1.404921,-1.404922 -1.404921,-3.642094 0,-5.047016 L 20.89992,31.35288 c 0.702461,-0.702461 1.655288,-1.019109 2.572037,-1.019109 0.916749,0 1.821047,0.316648 2.523508,1.019109 l 0.436761,0.436761 4.270552,-4.124965 -3.008798,-3.008798 c -1.178598,-1.178597 -2.68389,-1.747043 -4.222023,-1.747043 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#a32187;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;enable-background:accumulate" />
-    </g>
+    <path
+       class="cls-1"
+       d="m 28.105587,21.689095 -2.745638,-2.728006 0.01258,-0.01258 -2.094336,-2.081018 -0.383437,0.386321 a 2.4259259,2.4259353 0 0 0 0.01117,3.430802 l 3.119002,3.098844 z"
+       id="path1"
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#e62531;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000" />
+    <path
+       class="cls-1"
+       d="M 37.364282,18.19961 31.33043,12.204979 a 2.4259259,2.4259353 0 0 0 -3.430784,0.01117 l -2.033128,2.046455 2.094336,2.080658 1.662287,-1.673095 5.286775,5.254753 -6.343844,6.383468 0.373362,0.370843 a 2.4262861,2.4262954 0 0 0 3.431148,-0.01117 l 5.004505,-5.037656 a 2.4259259,2.4259353 0 0 0 -0.01083,-3.430798 z"
+       id="path2"
+       style="display:inline;fill:#e62531;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       class="cls-2"
+       d="m 23.869038,26.310898 2.74564,2.728012 -0.01262,0.01262 2.094331,2.08066 0.384884,-0.385963 a 2.4259259,2.4259353 0 0 0 -0.01117,-3.430797 l -3.121157,-3.098851 z"
+       id="path3"
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#b62f88;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000" />
+    <path
+       class="cls-2"
+       d="m 14.610336,29.800385 6.033853,5.994635 a 2.4259259,2.4259353 0 0 0 3.430789,-0.01117 l 2.033123,-2.046457 -2.09433,-2.080656 -1.662286,1.673097 -5.286777,-5.252953 6.343843,-6.385272 -0.373357,-0.370843 a 2.4259259,2.4259353 0 0 0 -3.430789,0.01117 l -5.004869,5.037652 a 2.4259259,2.4259353 0 0 0 0.01079,3.430798 z"
+       id="path4"
+       style="display:inline;fill:#b62f88;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       class="cls-3"
+       d="m 23.752746,21.856154 -2.727996,2.745649 -0.01262,-0.01296 -2.08101,2.09434 0.38632,0.383804 a 2.4259259,2.4259353 0 0 0 3.43079,-0.01117 l 3.098832,-3.119007 z"
+       id="path5"
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#0063a7;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000" />
+    <path
+       class="cls-3"
+       d="m 20.263274,12.597416 -5.994607,6.033519 a 2.4262861,2.4262954 0 0 0 0.01117,3.43116 l 2.046446,2.032773 2.080649,-2.094339 -1.673086,-1.661934 5.254733,-5.287159 6.383446,6.343871 0.370837,-0.373004 a 2.4262861,2.4262954 0 0 0 -0.01117,-3.431157 l -5.037633,-5.00453 a 2.4259259,2.4259353 0 0 0 -3.430785,0.01079 z"
+       id="path6"
+       style="display:inline;fill:#0063a7;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       class="cls-4"
+       d="m 28.24744,26.117562 2.727638,-2.745648 0.01296,0.01296 2.080651,-2.091819 -0.38704,-0.385604 a 2.4262861,2.4262954 0 0 0 -3.431148,0.01117 l -3.098477,3.119008 z"
+       id="path16"
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#00a3b7;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000" />
+    <path
+       class="cls-4"
+       d="m 31.736913,35.377018 5.994253,-6.033522 a 2.4262861,2.4262954 0 0 0 -0.01083,-3.43116 l -2.046445,-2.032768 -2.080648,2.093977 1.672728,1.661935 -5.252572,5.286799 -6.385245,-6.343151 -0.370839,0.373 a 2.4259259,2.4259353 0 0 0 0.01116,3.431162 l 5.037276,5.004525 a 2.4262861,2.4262954 0 0 0 3.431143,-0.01083 z"
+       id="path17"
+       style="display:inline;fill:#00a3b7;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/icons/BIM_IfcProperties.svg
+++ b/icons/BIM_IfcProperties.svg
@@ -2,28 +2,19 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="48.000000px"
    height="48.000000px"
    id="svg249"
-   sodipodi:version="0.32"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="BIM_IfcProperties.svg"
-   inkscape:export-filename="/home/jimmac/gfx/novell/pdes/trunk/docs/BIGmime-text.png"
-   inkscape:export-xdpi="240.00000"
-   inkscape:export-ydpi="240.00000"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3">
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5060"
        id="radialGradient5031"
        gradientUnits="userSpaceOnUse"
@@ -34,7 +25,6 @@
        fy="486.64789"
        r="117.14286" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5060">
       <stop
          style="stop-color:black;stop-opacity:1;"
@@ -46,7 +36,6 @@
          id="stop5064" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5060"
        id="radialGradient5029"
        gradientUnits="userSpaceOnUse"
@@ -72,7 +61,6 @@
          id="stop5052" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5048"
        id="linearGradient5027"
        gradientUnits="userSpaceOnUse"
@@ -81,29 +69,6 @@
        y1="366.64789"
        x2="302.85715"
        y2="609.50507" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4542">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4544" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4546" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4542"
-       id="radialGradient4548"
-       cx="24.306795"
-       cy="42.07798"
-       fx="24.306795"
-       fy="42.07798"
-       r="15.821514"
-       gradientTransform="matrix(1.000000,0.000000,0.000000,0.284916,-6.310056e-16,30.08928)"
-       gradientUnits="userSpaceOnUse" />
     <linearGradient
        id="linearGradient15662">
       <stop
@@ -171,21 +136,6 @@
          offset="1.0000000"
          id="stop261" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient12512">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1.0000000;"
-         offset="0.0000000"
-         id="stop12513" />
-      <stop
-         style="stop-color:#fff520;stop-opacity:0.89108908;"
-         offset="0.50000000"
-         id="stop12517" />
-      <stop
-         style="stop-color:#fff300;stop-opacity:0.0000000;"
-         offset="1.0000000"
-         id="stop12514" />
-    </linearGradient>
     <radialGradient
        r="37.751713"
        fy="3.7561285"
@@ -195,8 +145,7 @@
        gradientTransform="matrix(0.968273,0.000000,0.000000,1.032767,3.353553,0.646447)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15656"
-       xlink:href="#linearGradient269"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient269" />
     <radialGradient
        r="86.708450"
        fy="35.736916"
@@ -206,8 +155,7 @@
        gradientTransform="scale(0.960493,1.041132)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15658"
-       xlink:href="#linearGradient259"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient259" />
     <radialGradient
        r="38.158695"
        fy="7.2678967"
@@ -217,10 +165,8 @@
        gradientTransform="matrix(0.968273,0.000000,0.000000,1.032767,3.353553,0.646447)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15668"
-       xlink:href="#linearGradient15662"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient15662" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#aigrd2"
        id="radialGradient2283"
        gradientUnits="userSpaceOnUse"
@@ -231,7 +177,6 @@
        fy="114.5684"
        r="5.256" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#aigrd3"
        id="radialGradient2285"
        gradientUnits="userSpaceOnUse"
@@ -242,26 +187,6 @@
        fy="64.5679"
        r="5.257" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="0.32941176"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11.313708"
-     inkscape:cx="1.7948676"
-     inkscape:cy="19.713379"
-     inkscape:current-layer="layer4"
-     showgrid="false"
-     inkscape:grid-bbox="true"
-     inkscape:document-units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="1051"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:showpageshadow="false"
-     inkscape:window-maximized="1" />
   <metadata
      id="metadata4">
     <rdf:RDF>
@@ -270,7 +195,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Jakub Steiner</dc:title>
@@ -298,9 +222,7 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Shadow"
-     id="layer6"
-     inkscape:groupmode="layer">
+     id="layer6">
     <g
        style="display:inline"
        id="g5022"
@@ -313,21 +235,17 @@
          id="rect4173"
          style="opacity:0.40206185;color:black;fill:url(#linearGradient5027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
       <path
-         sodipodi:nodetypes="cccc"
          id="path5058"
          d="M -219.61876,-150.68038 C -219.61876,-150.68038 -219.61876,327.65041 -219.61876,327.65041 C -76.744594,328.55086 125.78146,220.48075 125.78138,88.454235 C 125.78138,-43.572302 -33.655436,-150.68036 -219.61876,-150.68038 z "
          style="opacity:0.40206185;color:black;fill:url(#radialGradient5029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
       <path
          style="opacity:0.40206185;color:black;fill:url(#radialGradient5031);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
          d="M -1559.2523,-150.68038 C -1559.2523,-150.68038 -1559.2523,327.65041 -1559.2523,327.65041 C -1702.1265,328.55086 -1904.6525,220.48075 -1904.6525,88.454235 C -1904.6525,-43.572302 -1745.2157,-150.68036 -1559.2523,-150.68038 z "
-         id="path5018"
-         sodipodi:nodetypes="cccc" />
+         id="path5018" />
     </g>
   </g>
   <g
      id="layer1"
-     inkscape:label="Base"
-     inkscape:groupmode="layer"
      style="display:inline">
     <rect
        ry="1.1490486"
@@ -406,35 +324,28 @@
          style="fill:url(#radialGradient2285);fill-rule:nonzero;stroke:none;stroke-miterlimit:4.0000000" />
     </g>
     <path
-       sodipodi:nodetypes="cc"
        id="path15672"
        d="M 11.505723,5.4942766 L 11.505723,43.400869"
        style="fill:none;fill-opacity:0.75000000;fill-rule:evenodd;stroke:#000000;stroke-width:0.98855311;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.0000000;stroke-opacity:0.017543854" />
     <path
-       sodipodi:nodetypes="cc"
        id="path15674"
        d="M 12.500000,5.0205154 L 12.500000,43.038228"
        style="fill:none;fill-opacity:0.75000000;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.0000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.0000000;stroke-opacity:0.20467831" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer4"
-     inkscape:label="new"
      style="display:inline">
     <path
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:14.22254467px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, ';letter-spacing:0px;word-spacing:0px;fill:#a32187;fill-opacity:1;stroke:#510044;stroke-width:0.96681237;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 17.928281,15.157463 a 0.90862386,1.09399 0 0 0 -0.584939,0.285556 l -5.319741,5.836858 a 0.90862386,1.09399 0 0 0 -0.296156,0.807839 v 3.660428 a 0.90862386,1.09399 0 0 0 0.294927,0.80784 l 5.319741,5.848695 a 0.90862386,1.09399 0 0 0 1.521332,-0.80784 v -4.364697 a 0.90862386,1.09399 0 0 0 -0.320734,-0.834471 l -2.414713,-2.466424 2.413485,-2.454589 a 0.90862386,1.09399 0 0 0 0.321962,-0.83595 v -4.389851 a 0.90862386,1.09399 0 0 0 -0.935164,-1.093394 z"
-       id="path901"
-       inkscape:connector-curvature="0" />
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:14.2225px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, ';letter-spacing:0px;word-spacing:0px;fill:#b62f88;fill-opacity:1;stroke:#230b1c;stroke-width:0.966812;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.928281,15.24926 a 0.90862386,1.09399 0 0 0 -0.584939,0.285556 l -5.319741,5.836858 a 0.90862386,1.09399 0 0 0 -0.296156,0.807839 v 3.660428 a 0.90862386,1.09399 0 0 0 0.294927,0.80784 l 5.319741,5.848695 a 0.90862386,1.09399 0 0 0 1.521332,-0.80784 v -4.364697 a 0.90862386,1.09399 0 0 0 -0.320734,-0.834471 l -2.414713,-2.466424 2.413485,-2.454589 a 0.90862386,1.09399 0 0 0 0.321962,-0.83595 V 16.342654 A 0.90862386,1.09399 0 0 0 19.928281,15.24926 Z"
+       id="path901" />
     <path
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:14.22254467px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, ';letter-spacing:0px;word-spacing:0px;fill:#da0640;fill-opacity:1;stroke:#4f071b;stroke-width:0.96681237;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 23.54145,14.601364 a 0.90033599,1.0840113 0 0 0 -0.894358,0.965105 l -1.503903,16.447063 a 0.90033599,1.0840113 0 0 0 0.894358,1.201511 h 2.047638 a 0.90033599,1.0840113 0 0 0 0.894357,-0.963807 l 1.512534,-16.447062 a 0.90033599,1.0840113 0 0 0 -0.894359,-1.20281 z"
-       id="path903"
-       inkscape:connector-curvature="0" />
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:14.2225px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, ';letter-spacing:0px;word-spacing:0px;fill:#e62531;fill-opacity:1;stroke:#220c0d;stroke-width:0.966812;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 25.54145,14.693161 a 0.90033599,1.0840113 0 0 0 -0.894358,0.965105 l -1.503903,16.447063 a 0.90033599,1.0840113 0 0 0 0.894358,1.201511 h 2.047638 a 0.90033599,1.0840113 0 0 0 0.894357,-0.963808 l 1.512534,-16.447061 a 0.90033599,1.0840113 0 0 0 -0.894359,-1.20281 z"
+       id="path903" />
     <path
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:14.22254467px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, ';letter-spacing:0px;word-spacing:0px;fill:#1b8fa7;fill-opacity:1;stroke:#003d4a;stroke-width:0.96681237;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 30.371503,14.848327 a 1.3736936,1.6539374 0 0 0 -1.42779,1.652674 v 4.282518 a 1.3736936,1.6539374 0 0 0 0.487918,1.26296 l 1.914508,1.947124 -1.916906,1.958671 a 1.3736936,1.6539374 0 0 0 -0.48552,1.261517 v 4.25798 a 1.3736936,1.6539374 0 0 0 2.300527,1.221103 l 5.189674,-5.705694 a 1.3736936,1.6539374 0 0 0 0.447158,-1.221103 v -3.57093 a 1.3736936,1.6539374 0 0 0 -0.448358,-1.222545 l -5.189673,-5.694147 a 1.3736936,1.6539374 0 0 0 -0.871538,-0.430128 z"
-       id="path905"
-       inkscape:connector-curvature="0" />
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:14.2225px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, ';letter-spacing:0px;word-spacing:0px;fill:#00a3b7;fill-opacity:1;stroke:#0c2022;stroke-width:0.966812;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 32.371503,14.940124 a 1.3736936,1.6539374 0 0 0 -1.42779,1.652674 v 4.282518 a 1.3736936,1.6539374 0 0 0 0.487918,1.26296 l 1.914508,1.947124 -1.916906,1.958671 a 1.3736936,1.6539374 0 0 0 -0.48552,1.261517 v 4.25798 a 1.3736936,1.6539374 0 0 0 2.300527,1.221103 l 5.189674,-5.705694 a 1.3736936,1.6539374 0 0 0 0.447158,-1.221103 v -3.57093 a 1.3736936,1.6539374 0 0 0 -0.448358,-1.222545 l -5.189673,-5.694147 a 1.3736936,1.6539374 0 0 0 -0.871538,-0.430128 z"
+       id="path905" />
   </g>
 </svg>

--- a/icons/BIM_IfcQuantities.svg
+++ b/icons/BIM_IfcQuantities.svg
@@ -2,28 +2,19 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="48.000000px"
    height="48.000000px"
    id="svg249"
-   sodipodi:version="0.32"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="BIM_IfcQuantitie.svg"
-   inkscape:export-filename="/home/jimmac/gfx/novell/pdes/trunk/docs/BIGmime-text.png"
-   inkscape:export-xdpi="240.00000"
-   inkscape:export-ydpi="240.00000"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3">
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5060"
        id="radialGradient5031"
        gradientUnits="userSpaceOnUse"
@@ -34,7 +25,6 @@
        fy="486.64789"
        r="117.14286" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5060">
       <stop
          style="stop-color:black;stop-opacity:1;"
@@ -46,7 +36,6 @@
          id="stop5064" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5060"
        id="radialGradient5029"
        gradientUnits="userSpaceOnUse"
@@ -72,7 +61,6 @@
          id="stop5052" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5048"
        id="linearGradient5027"
        gradientUnits="userSpaceOnUse"
@@ -81,29 +69,6 @@
        y1="366.64789"
        x2="302.85715"
        y2="609.50507" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4542">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4544" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4546" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4542"
-       id="radialGradient4548"
-       cx="24.306795"
-       cy="42.07798"
-       fx="24.306795"
-       fy="42.07798"
-       r="15.821514"
-       gradientTransform="matrix(1.000000,0.000000,0.000000,0.284916,-6.310056e-16,30.08928)"
-       gradientUnits="userSpaceOnUse" />
     <linearGradient
        id="linearGradient15662">
       <stop
@@ -171,21 +136,6 @@
          offset="1.0000000"
          id="stop261" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient12512">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1.0000000;"
-         offset="0.0000000"
-         id="stop12513" />
-      <stop
-         style="stop-color:#fff520;stop-opacity:0.89108908;"
-         offset="0.50000000"
-         id="stop12517" />
-      <stop
-         style="stop-color:#fff300;stop-opacity:0.0000000;"
-         offset="1.0000000"
-         id="stop12514" />
-    </linearGradient>
     <radialGradient
        r="37.751713"
        fy="3.7561285"
@@ -195,8 +145,7 @@
        gradientTransform="matrix(0.968273,0.000000,0.000000,1.032767,3.353553,0.646447)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15656"
-       xlink:href="#linearGradient269"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient269" />
     <radialGradient
        r="86.708450"
        fy="35.736916"
@@ -206,8 +155,7 @@
        gradientTransform="scale(0.960493,1.041132)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15658"
-       xlink:href="#linearGradient259"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient259" />
     <radialGradient
        r="38.158695"
        fy="7.2678967"
@@ -217,10 +165,8 @@
        gradientTransform="matrix(0.968273,0.000000,0.000000,1.032767,3.353553,0.646447)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15668"
-       xlink:href="#linearGradient15662"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient15662" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#aigrd2"
        id="radialGradient2283"
        gradientUnits="userSpaceOnUse"
@@ -231,7 +177,6 @@
        fy="114.5684"
        r="5.256" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#aigrd3"
        id="radialGradient2285"
        gradientUnits="userSpaceOnUse"
@@ -242,26 +187,6 @@
        fy="64.5679"
        r="5.257" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="0.32941176"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11.313708"
-     inkscape:cx="7.743654"
-     inkscape:cy="24.67408"
-     inkscape:current-layer="layer4"
-     showgrid="false"
-     inkscape:grid-bbox="true"
-     inkscape:document-units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="1051"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:showpageshadow="false"
-     inkscape:window-maximized="1" />
   <metadata
      id="metadata4">
     <rdf:RDF>
@@ -270,7 +195,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
         <dc:creator>
           <cc:Agent>
             <dc:title>Jakub Steiner</dc:title>
@@ -298,9 +222,7 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Shadow"
-     id="layer6"
-     inkscape:groupmode="layer">
+     id="layer6">
     <g
        style="display:inline"
        id="g5022"
@@ -313,21 +235,17 @@
          id="rect4173"
          style="opacity:0.40206185;color:black;fill:url(#linearGradient5027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
       <path
-         sodipodi:nodetypes="cccc"
          id="path5058"
          d="M -219.61876,-150.68038 C -219.61876,-150.68038 -219.61876,327.65041 -219.61876,327.65041 C -76.744594,328.55086 125.78146,220.48075 125.78138,88.454235 C 125.78138,-43.572302 -33.655436,-150.68036 -219.61876,-150.68038 z "
          style="opacity:0.40206185;color:black;fill:url(#radialGradient5029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
       <path
          style="opacity:0.40206185;color:black;fill:url(#radialGradient5031);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
          d="M -1559.2523,-150.68038 C -1559.2523,-150.68038 -1559.2523,327.65041 -1559.2523,327.65041 C -1702.1265,328.55086 -1904.6525,220.48075 -1904.6525,88.454235 C -1904.6525,-43.572302 -1745.2157,-150.68036 -1559.2523,-150.68038 z "
-         id="path5018"
-         sodipodi:nodetypes="cccc" />
+         id="path5018" />
     </g>
   </g>
   <g
      id="layer1"
-     inkscape:label="Base"
-     inkscape:groupmode="layer"
      style="display:inline">
     <rect
        ry="1.1490486"
@@ -406,41 +324,37 @@
          style="fill:url(#radialGradient2285);fill-rule:nonzero;stroke:none;stroke-miterlimit:4.0000000" />
     </g>
     <path
-       sodipodi:nodetypes="cc"
        id="path15672"
        d="M 11.505723,5.4942766 L 11.505723,43.400869"
        style="fill:none;fill-opacity:0.75000000;fill-rule:evenodd;stroke:#000000;stroke-width:0.98855311;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.0000000;stroke-opacity:0.017543854" />
     <path
-       sodipodi:nodetypes="cc"
        id="path15674"
        d="M 12.500000,5.0205154 L 12.500000,43.038228"
        style="fill:none;fill-opacity:0.75000000;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.0000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.0000000;stroke-opacity:0.20467831" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer4"
-     inkscape:label="new"
      style="display:inline">
     <rect
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#a32187;fill-opacity:1;fill-rule:nonzero;stroke:#300026;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#b62f88;fill-opacity:1;fill-rule:nonzero;stroke:#230b1c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect878"
-       width="5.038136"
+       width="5.5230751"
        height="17.500893"
-       x="15.644738"
-       y="17.594408" />
+       x="15.394699"
+       y="18.519922" />
     <rect
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#da0640;fill-opacity:1;fill-rule:nonzero;stroke:#171717;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#e62531;fill-opacity:1;fill-rule:nonzero;stroke:#230b0d;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect878-3"
-       width="5.0381336"
+       width="5.5230727"
        height="24.041628"
-       x="22.98097"
-       y="11.053671" />
+       x="23.437071"
+       y="11.979185" />
     <rect
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#1b8fa7;fill-opacity:1;fill-rule:nonzero;stroke:#002127;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#00a3b7;fill-opacity:1;fill-rule:nonzero;stroke:#0c2022;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="rect878-3-6"
-       width="5.0381355"
+       width="5.5230746"
        height="9.9878807"
-       x="30.317204"
-       y="25.107418" />
+       x="31.479443"
+       y="26.032932" />
   </g>
 </svg>

--- a/icons/BIM_Phases.svg
+++ b/icons/BIM_Phases.svg
@@ -5,15 +5,7 @@
    width="48.000000px"
    height="48.000000px"
    id="svg249"
-   sodipodi:version="0.32"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
-   sodipodi:docname="BIM_Phases.svg"
-   inkscape:export-filename="/home/jimmac/gfx/novell/pdes/trunk/docs/BIGmime-text.png"
-   inkscape:export-xdpi="240.00000"
-   inkscape:export-ydpi="240.00000"
    version="1.1"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
@@ -23,7 +15,6 @@
   <defs
      id="defs3">
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5060"
        id="radialGradient5031"
        gradientUnits="userSpaceOnUse"
@@ -34,7 +25,6 @@
        fy="486.64789"
        r="117.14286" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient5060">
       <stop
          style="stop-color:black;stop-opacity:1;"
@@ -46,7 +36,6 @@
          id="stop5064" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5060"
        id="radialGradient5029"
        gradientUnits="userSpaceOnUse"
@@ -72,7 +61,6 @@
          id="stop5052" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient5048"
        id="linearGradient5027"
        gradientUnits="userSpaceOnUse"
@@ -81,29 +69,6 @@
        y1="366.64789"
        x2="302.85715"
        y2="609.50507" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4542">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4544" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4546" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4542"
-       id="radialGradient4548"
-       cx="24.306795"
-       cy="42.07798"
-       fx="24.306795"
-       fy="42.07798"
-       r="15.821514"
-       gradientTransform="matrix(1.000000,0.000000,0.000000,0.284916,-6.310056e-16,30.08928)"
-       gradientUnits="userSpaceOnUse" />
     <linearGradient
        id="linearGradient15662">
       <stop
@@ -171,21 +136,6 @@
          offset="1.0000000"
          id="stop261" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient12512">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1.0000000;"
-         offset="0.0000000"
-         id="stop12513" />
-      <stop
-         style="stop-color:#fff520;stop-opacity:0.89108908;"
-         offset="0.50000000"
-         id="stop12517" />
-      <stop
-         style="stop-color:#fff300;stop-opacity:0.0000000;"
-         offset="1.0000000"
-         id="stop12514" />
-    </linearGradient>
     <radialGradient
        r="37.751713"
        fy="3.7561285"
@@ -195,8 +145,7 @@
        gradientTransform="matrix(0.968273,0.000000,0.000000,1.032767,3.353553,0.646447)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15656"
-       xlink:href="#linearGradient269"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient269" />
     <radialGradient
        r="86.708450"
        fy="35.736916"
@@ -206,8 +155,7 @@
        gradientTransform="scale(0.960493,1.041132)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15658"
-       xlink:href="#linearGradient259"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient259" />
     <radialGradient
        r="38.158695"
        fy="7.2678967"
@@ -217,10 +165,8 @@
        gradientTransform="matrix(0.968273,0.000000,0.000000,1.032767,3.353553,0.646447)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient15668"
-       xlink:href="#linearGradient15662"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient15662" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#aigrd2"
        id="radialGradient2283"
        gradientUnits="userSpaceOnUse"
@@ -231,7 +177,6 @@
        fy="114.5684"
        r="5.256" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#aigrd3"
        id="radialGradient2285"
        gradientUnits="userSpaceOnUse"
@@ -242,27 +187,6 @@
        fy="64.5679"
        r="5.257" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="0.32941176"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="16"
-     inkscape:cx="23.3125"
-     inkscape:cy="24.40625"
-     inkscape:current-layer="layer4"
-     showgrid="false"
-     inkscape:grid-bbox="true"
-     inkscape:document-units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="1051"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:showpageshadow="false"
-     inkscape:window-maximized="1"
-     inkscape:pagecheckerboard="0" />
   <metadata
      id="metadata4">
     <rdf:RDF>
@@ -298,9 +222,7 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Shadow"
-     id="layer6"
-     inkscape:groupmode="layer">
+     id="layer6">
     <g
        style="display:inline"
        id="g5022"
@@ -313,21 +235,17 @@
          id="rect4173"
          style="opacity:0.40206185;color:black;fill:url(#linearGradient5027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
       <path
-         sodipodi:nodetypes="cccc"
          id="path5058"
          d="M -219.61876,-150.68038 C -219.61876,-150.68038 -219.61876,327.65041 -219.61876,327.65041 C -76.744594,328.55086 125.78146,220.48075 125.78138,88.454235 C 125.78138,-43.572302 -33.655436,-150.68036 -219.61876,-150.68038 z "
          style="opacity:0.40206185;color:black;fill:url(#radialGradient5029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
       <path
          style="opacity:0.40206185;color:black;fill:url(#radialGradient5031);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
          d="M -1559.2523,-150.68038 C -1559.2523,-150.68038 -1559.2523,327.65041 -1559.2523,327.65041 C -1702.1265,328.55086 -1904.6525,220.48075 -1904.6525,88.454235 C -1904.6525,-43.572302 -1745.2157,-150.68036 -1559.2523,-150.68038 z "
-         id="path5018"
-         sodipodi:nodetypes="cccc" />
+         id="path5018" />
     </g>
   </g>
   <g
      id="layer1"
-     inkscape:label="Base"
-     inkscape:groupmode="layer"
      style="display:inline">
     <rect
        ry="1.1490486"
@@ -406,43 +324,35 @@
          style="fill:url(#radialGradient2285);fill-rule:nonzero;stroke:none;stroke-miterlimit:4.0000000" />
     </g>
     <path
-       sodipodi:nodetypes="cc"
        id="path15672"
        d="M 11.505723,5.4942766 L 11.505723,43.400869"
        style="fill:none;fill-opacity:0.75000000;fill-rule:evenodd;stroke:#000000;stroke-width:0.98855311;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.0000000;stroke-opacity:0.017543854" />
     <path
-       sodipodi:nodetypes="cc"
        id="path15674"
        d="M 12.500000,5.0205154 L 12.500000,43.038228"
        style="fill:none;fill-opacity:0.75000000;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.0000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.0000000;stroke-opacity:0.20467831" />
   </g>
   <g
-     inkscape:groupmode="layer"
      id="layer4"
-     inkscape:label="new"
      style="display:inline">
     <path
-       style="display:inline;fill:none;fill-rule:evenodd;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#555753;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        d="m 13.935345,11.436919 0,30.325987"
-       id="path1641-7"
-       sodipodi:nodetypes="cc" />
+       id="path1641-7" />
     <path
-       style="display:inline;fill:none;fill-rule:evenodd;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#555753;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        d="m 21.935345,11.569501 0,30.193405"
-       id="path1641-7-5"
-       sodipodi:nodetypes="cc" />
+       id="path1641-7-5" />
     <path
-       style="display:inline;fill:none;fill-rule:evenodd;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#555753;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        d="m 29.935345,11.569501 0,30.193405"
-       id="path1641-7-5-5"
-       sodipodi:nodetypes="cc" />
+       id="path1641-7-5-5" />
     <path
-       style="display:inline;fill:none;fill-rule:evenodd;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#555753;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        d="m 37.935345,11.613696 v 30.14921"
-       id="path1641-7-5-5-6"
-       sodipodi:nodetypes="cc" />
+       id="path1641-7-5-5-6" />
     <rect
-       style="color:#000000;overflow:visible;fill:#0070ff;stroke-width:1;stroke-linejoin:round;stop-color:#000000;fill-opacity:1;stroke:#373737;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       style="color:#000000;overflow:visible;fill:#0063a7;stroke-width:1;stroke-linejoin:round;stop-color:#000000;fill-opacity:1;stroke:#0c1922;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-linecap:round"
        id="rect987"
        width="12.020816"
        height="4.5961967"
@@ -451,7 +361,7 @@
        rx="0.69999999"
        ry="0.60000002" />
     <rect
-       style="color:#000000;display:inline;overflow:visible;fill:#0070ff;fill-opacity:1;stroke:#373737;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+       style="color:#000000;display:inline;overflow:visible;fill:#b62f88;fill-opacity:1;stroke:#230b1c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:round;stroke-dashoffset:0;-inkscape-stroke:none;stop-opacity:1"
        id="rect987-3"
        width="12.020816"
        height="4.5961967"
@@ -460,7 +370,7 @@
        rx="0.69999999"
        ry="0.60000002" />
     <rect
-       style="color:#000000;display:inline;overflow:visible;fill:#ff4c00;fill-opacity:1;stroke:#373737;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+       style="color:#000000;display:inline;overflow:visible;fill:#e62531;fill-opacity:1;stroke:#220c0d;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
        id="rect987-6"
        width="18.083315"
        height="4.5961971"
@@ -469,7 +379,7 @@
        rx="0.69999999"
        ry="0.60000002" />
     <rect
-       style="color:#000000;display:inline;overflow:visible;fill:#ff4c00;fill-opacity:1;stroke:#373737;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+       style="color:#000000;display:inline;overflow:visible;fill:#00a3b7;fill-opacity:1;stroke:#0c2022;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
        id="rect987-6-2"
        width="18.083315"
        height="4.5961971"
@@ -478,68 +388,20 @@
        rx="0.69999999"
        ry="0.60000002" />
     <path
-       sodipodi:type="star"
-       style="color:#000000;overflow:visible;fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       style="color:#000000;overflow:visible;fill:#babdb6;fill-opacity:1;stroke:#555753;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stroke-linecap:round"
        id="path3592"
-       inkscape:flatsided="true"
-       sodipodi:sides="3"
-       sodipodi:cx="13.888868"
-       sodipodi:cy="8.0178928"
-       sodipodi:r1="1.8679662"
-       sodipodi:r2="0.93398309"
-       sodipodi:arg1="1.5707963"
-       sodipodi:arg2="2.6179939"
-       inkscape:rounded="0"
-       inkscape:randomized="0"
-       d="m 13.888868,9.885859 -1.617706,-2.8019492 3.235412,-10e-8 z"
-       inkscape:transform-center-y="0.46699155" />
+       d="m 13.888868,9.885859 -1.617706,-2.8019492 3.235412,-10e-8 z" />
     <path
-       sodipodi:type="star"
-       style="color:#000000;display:inline;overflow:visible;fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       style="color:#000000;display:inline;overflow:visible;fill:#babdb6;fill-opacity:1;stroke:#555753;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stroke-linecap:round"
        id="path3592-2"
-       inkscape:flatsided="true"
-       sodipodi:sides="3"
-       sodipodi:cx="21.888868"
-       sodipodi:cy="8.0178928"
-       sodipodi:r1="1.8679662"
-       sodipodi:r2="0.93398309"
-       sodipodi:arg1="1.5707963"
-       sodipodi:arg2="2.6179939"
-       inkscape:rounded="0"
-       inkscape:randomized="0"
-       inkscape:transform-center-y="0.46699155"
        d="m 21.888868,9.885859 -1.617706,-2.8019492 3.235412,-10e-8 z" />
     <path
-       sodipodi:type="star"
-       style="color:#000000;display:inline;overflow:visible;fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       style="color:#000000;display:inline;overflow:visible;fill:#babdb6;fill-opacity:1;stroke:#555753;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stroke-linecap:round"
        id="path3592-2-9"
-       inkscape:flatsided="true"
-       sodipodi:sides="3"
-       sodipodi:cx="29.888868"
-       sodipodi:cy="8.0178928"
-       sodipodi:r1="1.8679662"
-       sodipodi:r2="0.93398309"
-       sodipodi:arg1="1.5707963"
-       sodipodi:arg2="2.6179939"
-       inkscape:rounded="0"
-       inkscape:randomized="0"
-       inkscape:transform-center-y="0.46699155"
        d="m 29.888868,9.885859 -1.617706,-2.8019492 3.235412,-10e-8 z" />
     <path
-       sodipodi:type="star"
-       style="color:#000000;display:inline;overflow:visible;fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       style="color:#000000;display:inline;overflow:visible;fill:#babdb6;fill-opacity:1;stroke:#555753;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stroke-linecap:round"
        id="path3592-2-9-1"
-       inkscape:flatsided="true"
-       sodipodi:sides="3"
-       sodipodi:cx="37.888866"
-       sodipodi:cy="8.0178928"
-       sodipodi:r1="1.8679662"
-       sodipodi:r2="0.93398309"
-       sodipodi:arg1="1.5707963"
-       sodipodi:arg2="2.6179939"
-       inkscape:rounded="0"
-       inkscape:randomized="0"
-       inkscape:transform-center-y="0.46699155"
        d="m 37.888866,9.885859 -1.617706,-2.8019492 3.235413,-10e-8 z" />
   </g>
 </svg>

--- a/icons/IFC.svg
+++ b/icons/IFC.svg
@@ -2,82 +2,195 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg3007"
+   width="64"
+   height="64"
+   id="svg2869"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="New document 4">
+   viewBox="0 0 64 64"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs3009" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="7.7781746"
-     inkscape:cx="32.615197"
-     inkscape:cy="37.232031"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:object-nodes="true"
-     inkscape:snap-smooth-nodes="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1053"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+  </defs>
   <metadata
-     id="metadata3012">
+     id="metadata2874">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer3"
+     style="display:inline">
     <path
-       style="color:#000000;fill:#a32187;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 23.493051,22.924165 c -1.538134,0 -3.091954,0.568446 -4.270552,1.747044 L 6.8961342,36.997574 c -2.3571939,2.357194 -2.3571939,6.183909 0,8.541103 L 19.222499,57.865042 c 2.357194,2.357194 6.13538,2.357194 8.492574,0 L 40.041438,45.538677 c 2.357194,-2.357194 2.357194,-6.183909 0,-8.541103 L 27.715073,24.671209 c -1.178597,-1.178598 -2.683889,-1.747044 -4.222022,-1.747044 z m 0,7.424936 c 0.916749,0 1.821047,0.316649 2.523507,1.019109 l 7.327879,7.376408 c 1.404921,1.404921 1.404921,3.642094 0,5.047015 l -7.327879,7.376408 c -1.404921,1.404921 -3.690623,1.404921 -5.095544,0 l -7.327879,-7.376408 c -1.40492,-1.404921 -1.40492,-3.642094 0,-5.047015 l 7.327879,-7.376408 c 0.702461,-0.70246 1.655287,-1.019109 2.572037,-1.019109 z"
-       id="rect3022-4"
-       inkscape:connector-curvature="0" />
+       class="cls-4"
+       d="m 37.215197,36.913806 6.32949,-6.371284 0.03007,0.03007 4.828159,-4.854072 -0.898129,-0.894796 a 5.6302037,5.6302256 0 0 0 -7.961988,0.02591 l -7.190025,7.237664 z"
+       id="path7"
+       style="fill:#00a3b7;stroke-width:1.00001" />
     <path
-       style="color:#000000;fill:#1b8fa7;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 41.379157,23.102951 c -1.538133,0 -3.091954,0.568446 -4.270552,1.747043 L 24.78224,37.176359 c -2.357194,2.357194 -2.357194,6.18391 0,8.541104 l 12.326365,12.326364 c 2.357194,2.357194 6.13538,2.357194 8.492574,0 L 57.927544,45.717463 c 2.357194,-2.357194 2.357194,-6.18391 0,-8.541104 L 45.601179,24.849994 C 44.422582,23.671397 42.91729,23.102951 41.379157,23.102951 z m 0,7.424936 c 0.916749,0 1.821047,0.316648 2.523507,1.019109 l 7.327879,7.376407 c 1.404921,1.404922 1.404921,3.642094 0,5.047016 l -7.327879,7.376407 c -1.404921,1.404921 -3.690623,1.404921 -5.095544,0 l -7.327879,-7.376407 c -1.404921,-1.404922 -1.404921,-3.642094 0,-5.047016 l 7.327879,-7.376407 c 0.702461,-0.702461 1.655287,-1.019109 2.572037,-1.019109 z"
-       id="rect3022-4-8"
-       inkscape:connector-curvature="0" />
+       class="cls-4"
+       d="m 45.312528,58.400403 13.90968,-14.000804 a 5.6302037,5.6302256 0 0 0 -0.02515,-7.962019 l -4.748784,-4.717046 -4.828149,4.859081 3.881571,3.856524 L 41.313085,52.704173 26.49611,37.984874 25.635575,38.850422 a 5.6293682,5.6293901 0 0 0 0.02591,7.962019 l 11.689013,11.613015 a 5.6302037,5.6302256 0 0 0 7.961979,-0.02515 z"
+       id="path8"
+       style="fill:#00a3b7;stroke-width:1.00001" />
     <path
-       style="color:#000000;fill:#004a95;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 22.088093,5.565902 c -1.538133,0 -3.091953,0.5684461 -4.270551,1.7470438 L 5.491177,19.639311 c -2.3571938,2.357194 -2.3571938,6.18391 0,8.541103 l 12.326365,12.326365 c 2.357194,2.357194 6.13538,2.357194 8.492574,0 L 38.636481,28.180414 c 2.357194,-2.357193 2.357194,-6.183909 0,-8.541103 L 26.310116,7.3129458 C 25.131518,6.1343481 23.626227,5.565902 22.088093,5.565902 z m 0,7.424936 c 0.91675,0 1.821048,0.316649 2.523508,1.01911 l 7.327879,7.376407 c 1.404921,1.404921 1.404921,3.642094 0,5.047016 l -7.327879,7.376407 c -1.404921,1.404921 -3.690623,1.404921 -5.095544,0 l -7.327878,-7.376407 c -1.404921,-1.404922 -1.404921,-3.642095 0,-5.047016 l 7.327878,-7.376407 c 0.70246,-0.702461 1.655287,-1.01911 2.572036,-1.01911 z"
-       id="rect3022-7"
-       inkscape:connector-curvature="0" />
+       class="cls-1"
+       d="m 36.886026,26.637538 -6.371261,-6.330347 0.0292,-0.0292 -4.859912,-4.829009 -0.889766,0.896459 a 5.6293682,5.6293901 0 0 0 0.02591,7.961187 l 7.237655,7.190877 z"
+       id="path1"
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#e62531;fill-opacity:1;stroke:#220c0d;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
     <path
-       style="color:#000000;fill:#da0640;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 39.971816,4.6619318 c -1.538133,0 -3.091954,0.5684461 -4.270552,1.7470438 l -5.192602,5.1926024 4.222022,4.173494 2.669095,-2.669095 c 0.702461,-0.702461 1.655288,-1.019109 2.572037,-1.019109 0.916749,0 1.821047,0.316648 2.523508,1.019109 l 7.327878,7.376408 c 1.404921,1.404921 1.404921,3.642094 0,5.047015 l -7.327878,7.376408 c -1.388531,1.38853 -3.63841,1.40466 -5.047016,0.04853 l -4.222023,4.173493 2.474979,2.474979 c 2.357194,2.357194 6.135381,2.357194 8.492574,0 L 56.520203,27.276444 c 2.357194,-2.357194 2.357194,-6.183909 0,-8.541103 L 44.193838,6.4089756 C 43.015241,5.2303779 41.509949,4.6619318 39.971816,4.6619318 z M 26.335168,15.775072 23.374899,18.735341 c -2.357194,2.357194 -2.357194,6.183909 0,8.541103 l 3.88232,3.88232 4.173493,-4.222023 -1.358811,-1.407341 c -1.404922,-1.404921 -1.404922,-3.642094 0,-5.047015 l 0.48529,-0.48529 -4.222023,-4.222023 z"
-       id="rect3022"
-       inkscape:connector-curvature="0" />
+       class="cls-1"
+       d="M 58.370856,18.540176 44.369285,4.6296202 a 5.6293682,5.6293901 0 0 0 -7.961147,0.025913 l -4.717878,4.7488063 4.859912,4.8281695 3.857341,-3.88242 12.267977,12.193671 -14.720906,14.812855 0.866386,0.860541 a 5.6302037,5.6302256 0 0 0 7.961988,-0.02591 l 11.61297,-11.689894 a 5.6293682,5.6293901 0 0 0 -0.02514,-7.961176 z"
+       id="path2"
+       style="fill:#e62531;stroke:#220c0d;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="color:#000000;fill:#a32187;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 23.471957,22.908835 c -1.538133,0 -3.091954,0.568446 -4.270551,1.747043 L 6.8750408,36.982243 c -2.3571939,2.357194 -2.3571939,6.18391 0,8.541104 l 2.7661527,2.766152 4.2705515,-4.173493 -0.339703,-0.339703 c -1.404921,-1.404922 -1.404921,-3.642094 0,-5.047016 L 20.89992,31.35288 c 0.702461,-0.702461 1.655288,-1.019109 2.572037,-1.019109 0.916749,0 1.821047,0.316648 2.523508,1.019109 l 0.436761,0.436761 4.270552,-4.124965 -3.008798,-3.008798 c -1.178598,-1.178597 -2.68389,-1.747043 -4.222023,-1.747043 z"
-       id="rect3022-4-4"
-       inkscape:connector-curvature="0" />
+       class="cls-2"
+       d="m 27.0551,37.362446 6.37127,6.330357 -0.02929,0.02929 4.859902,4.828179 0.89312,-0.895628 a 5.6293682,5.6293901 0 0 0 -0.02591,-7.961177 l -7.242652,-7.19089 z"
+       id="path3"
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#b62f88;fill-opacity:1;stroke:#230b1c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
+    <path
+       class="cls-2"
+       d="M 5.5702589,45.459809 19.57183,59.370374 a 5.6293682,5.6293901 0 0 0 7.961155,-0.02591 L 32.250854,54.595655 27.390953,49.767486 23.533614,53.649914 11.265634,41.460419 25.98654,26.643377 25.120165,25.782838 a 5.6293682,5.6293901 0 0 0 -7.961157,0.02591 L 5.5451976,37.498631 a 5.6293682,5.6293901 0 0 0 0.025041,7.961178 z"
+       id="path4"
+       style="fill:#b62f88;stroke:#230b1c;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       class="cls-3"
+       d="m 26.785246,27.025198 -6.330323,6.371284 -0.02929,-0.03007 -4.82899,4.859921 0.896456,0.890619 a 5.6293682,5.6293901 0 0 0 7.961157,-0.02591 l 7.190849,-7.237664 z"
+       id="path5"
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#0063a7;fill-opacity:1;stroke:#0c1922;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
+    <path
+       class="cls-3"
+       d="M 18.687915,5.5402733 4.7774132,19.541067 a 5.6302037,5.6302256 0 0 0 0.025913,7.962019 l 4.7487874,4.717054 4.8281484,-4.85992 -3.8824,-3.856524 12.193623,-12.268866 14.812806,14.720972 0.860527,-0.865558 a 5.6302037,5.6302256 0 0 0 -0.02591,-7.962009 L 26.649061,5.5152119 a 5.6293682,5.6293901 0 0 0 -7.961146,0.025042 z"
+       id="path6"
+       style="fill:#0063a7;stroke:#0c1922;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       class="cls-4"
+       d="m 37.215197,36.913806 6.32949,-6.371284 0.03007,0.03007 4.828159,-4.854072 -0.898129,-0.894796 a 5.6302037,5.6302256 0 0 0 -7.961988,0.02591 l -7.190025,7.237664 z"
+       id="path16"
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#00a3b7;fill-opacity:1;stroke:#0c2022;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
+    <path
+       class="cls-4"
+       d="m 45.312528,58.400403 13.90968,-14.000804 a 5.6302037,5.6302256 0 0 0 -0.02515,-7.962019 l -4.748784,-4.717046 -4.828149,4.859081 3.881571,3.856524 L 41.313085,52.704173 26.49611,37.984874 25.635575,38.850422 a 5.6293682,5.6293901 0 0 0 0.02591,7.962019 l 11.689013,11.613015 a 5.6302037,5.6302256 0 0 0 7.961979,-0.02515 z"
+       id="path17"
+       style="fill:#00a3b7;stroke:#0c2022;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       class="cls-4"
+       d="m 54.453125,33.845703 3.683594,3.660156 c 1.612441,1.602406 1.619808,4.227339 0.01758,5.839844 L 44.246094,57.34375 c -1.602392,1.612437 -4.227296,1.619859 -5.839844,0.01758 L 26.71875,45.75 c -1.545647,-1.535277 -1.612695,-4.007793 -0.205078,-5.630859 l 14.80664,14.707031 14.300782,-14.392578 -3.88086,-3.857422 z"
+       id="path27"
+       style="fill:#00a3b7;stroke:#00e3ff;stroke-width:1.49985;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.0001015,0,0,1.0001015,-0.00317145,-0.00690823)" />
+    <path
+       class="cls-4"
+       d="m 43.521484,24.691406 c 0.980402,-0.0032 1.967701,0.346449 2.751953,1.042969 l -2.736328,2.751953 -0.03125,-0.0293 -6.298828,6.337891 -2.732422,-2.710938 6.13086,-6.173828 c 0.805241,-0.810446 1.863023,-1.215323 2.916015,-1.21875 z"
+       id="path28"
+       style="font-variation-settings:normal;opacity:1;fill:#00a3b7;fill-opacity:1;stroke:#00e3ff;stroke-width:1.49985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       transform="matrix(1.0001015,0,0,1.0001015,-0.00317145,-0.00690823)" />
+    <path
+       class="cls-2"
+       d="m 31.888672,34.626953 6.177734,6.134766 c 1.556469,1.546352 1.613286,4.041094 0.175781,5.662109 l -2.720703,-2.703125 0.0293,-0.0293 -6.375,-6.333984 z"
+       id="path29"
+       style="fill:#b62f88;stroke:#d55dac;stroke-width:1.49985;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.0001015,0,0,1.0001015,-0.00317145,-0.00690823)" />
+    <path
+       class="cls-2"
+       d="m 21.138672,25.652344 c 0.966989,-0.0031 1.937996,0.335511 2.716797,1.011718 L 9.1464844,41.46875 23.542969,55.773437 l 3.855468,-3.882812 2.730469,2.714844 -3.660156,3.683593 c -1.601683,1.612178 -4.227479,1.619515 -5.839844,0.01758 L 6.6289062,44.398437 C 5.0167673,42.796425 5.0092787,40.170736 6.6113281,38.558594 L 18.224609,26.869141 c 0.804985,-0.81026 1.859903,-1.213366 2.914063,-1.216797 z"
+       id="path30"
+       style="font-variation-settings:normal;opacity:1;fill:#b62f88;fill-opacity:1;stroke:#d55dac;stroke-width:1.49985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       transform="matrix(1.0001015,0,0,1.0001015,-0.00317145,-0.00690823)" />
+    <path
+       class="cls-3"
+       d="m 22.667969,5.3847656 c 1.052716,-0.00331 2.115201,0.3956602 2.925781,1.2011719 l 11.6875,11.6113285 c 1.54516,1.535253 1.612714,4.006684 0.205078,5.630859 L 22.685547,9.1191406 8.3789063,23.513672 12.261719,27.371094 9.546875,30.103516 5.8632812,26.443359 C 4.2504878,24.840911 4.241972,22.215874 5.84375,20.603516 L 19.753906,6.6035156 c 0.805908,-0.8110081 1.861593,-1.2154395 2.914063,-1.21875 z"
+       id="path31"
+       style="fill:#0063a7;stroke:#0098ff;stroke-width:1.49985;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.0001015,0,0,1.0001015,-0.00317145,-0.00690823)" />
+    <path
+       class="cls-3"
+       d="m 26.792969,29.150391 2.730468,2.714843 -6.132812,6.171875 c -1.545223,1.555349 -4.040103,1.611733 -5.662109,0.175782 l 2.666015,-2.683594 0.0293,0.03125 z"
+       id="path32"
+       style="font-variation-settings:normal;opacity:1;fill:#0063a7;fill-opacity:1;stroke:#0098ff;stroke-width:1.49985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       transform="matrix(1.0001015,0,0,1.0001015,-0.00317145,-0.00690823)" />
+    <path
+       class="cls-1"
+       d="m 40.386719,4.5 c 1.052415,-0.00343 2.112414,0.3950076 2.923828,1.2011719 l 14,13.9082031 c 1.612141,1.601974 1.619609,4.227678 0.01758,5.839844 l -11.611328,11.6875 c -1.536439,1.546369 -4.010037,1.613803 -5.632813,0.205078 L 54.794922,22.542969 40.400391,8.234375 36.542969,12.117188 33.810547,9.4042969 37.472656,5.71875 C 38.278275,4.9078546 39.33394,4.5034267 40.386719,4.5 Z"
+       id="path33"
+       style="fill:#e62531;stroke:#f76e75;stroke-width:1.49985;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.0001015,0,0,1.0001015,-0.00317145,-0.00690823)" />
+    <path
+       class="cls-1"
+       d="m 25.701172,17.585937 2.71875,2.701172 -0.0293,0.0293 6.373047,6.333985 -2.712891,2.730468 -6.173828,-6.134765 C 24.321292,21.700547 24.264937,19.20807 25.701172,17.585937 Z"
+       id="path34"
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#e62531;fill-opacity:1;stroke:#f76e75;stroke-width:1.49985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+       transform="matrix(1.0001015,0,0,1.0001015,-0.00317145,-0.00690823)" />
   </g>
 </svg>


### PR DESCRIPTION
Update icons for better legibility on dark themes and current openBIM logo.
Tweaked colors to be consistent.
If you need different icons changed for the merge, also Arch/Draft, just let me know.

BIM logo currently is the only one pixelated:
![image](https://github.com/yorikvanhavre/BIM_Workbench/assets/6246609/d50f14d6-9eaf-4192-a9fe-112f2704c93b)
